### PR TITLE
NEW import_lines_from_object for invoices is now wrapped in subtitles

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2889,13 +2889,31 @@ if (empty($reshook)) {
 			if ($fromElement == 'commande') {
 				dol_include_once('/'.$fromElement.'/class/'.$fromElement.'.class.php');
 				$lineClassName = 'OrderLine';
+				$parent = new Commande($db);
 			} elseif ($fromElement == 'propal') {
 				dol_include_once('/comm/'.$fromElement.'/class/'.$fromElement.'.class.php');
 				$lineClassName = 'PropaleLigne';
+				$parent = new Propal($db);
 			}
 			$nextRang = count($object->lines) + 1;
 			$importCount = 0;
 			$error = 0;
+
+			// Add sub-total title
+			if (isset($parent)) {
+				$parent->fetch($fromElementid);
+				$label = '';
+				if ($parent->ref_client) {
+					$label .= $parent->ref_client." - (".$parent->ref.")";
+				} else {
+					$label .= "(".$parent->ref.")";
+				}
+				$sub_tot = new TSubtotal(); 
+				$sub_tot->addTitle($object, $label, 1);
+				$nextRang++;
+			}
+
+			// Import lines
 			foreach ($importLines as $lineId) {
 				$lineId = intval($lineId);
 				$originLine = new $lineClassName($db);
@@ -2946,6 +2964,9 @@ if (empty($reshook)) {
 					$error++;
 				}
 			}
+
+			// Add sub-total result
+			if (isset($parent)) {$sub_tot->addTotal($object, $label, 1);}
 
 			if ($error) {
 				setEventMessages($langs->trans('ErrorsOnXLines', $error), null, 'errors');


### PR DESCRIPTION
NEW import_lines_from_object for invoices is now wrapped in subtitles
When we import a line from a linked commande:
![image](https://github.com/user-attachments/assets/6e6d032d-6c3b-4c21-884f-e3c3b34b5d08)
The imported lines are wrapped in a subtotal of level 1:
![image](https://github.com/user-attachments/assets/716b8e5f-2d1f-49aa-a240-3c1e9df4106b)
