### PR TITLE
NEW Add commande on new situation invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2889,13 +2889,31 @@ if (empty($reshook)) {
 			if ($fromElement == 'commande') {
 				dol_include_once('/'.$fromElement.'/class/'.$fromElement.'.class.php');
 				$lineClassName = 'OrderLine';
+				$parent = new Commande($db);
 			} elseif ($fromElement == 'propal') {
 				dol_include_once('/comm/'.$fromElement.'/class/'.$fromElement.'.class.php');
 				$lineClassName = 'PropaleLigne';
+				$parent = new Propal($db);
 			}
 			$nextRang = count($object->lines) + 1;
 			$importCount = 0;
 			$error = 0;
+
+			// Add sub-total title
+			if (isset($parent)) {
+				$parent->fetch($fromElementid);
+				$label = '';
+				if ($parent->ref_client) {
+					$label .= $parent->ref_client." - (".$parent->ref.")";
+				} else {
+					$label .= "(".$parent->ref.")";
+				}
+				$sub_tot = new TSubtotal(); 
+				$sub_tot->addTitle($object, $label, 1);
+				$nextRang++;
+			}
+
+			// Import lines
 			foreach ($importLines as $lineId) {
 				$lineId = intval($lineId);
 				$originLine = new $lineClassName($db);
@@ -2946,6 +2964,9 @@ if (empty($reshook)) {
 					$error++;
 				}
 			}
+
+			// Add sub-total result
+			if (isset($parent)) {$sub_tot->addTotal($object, $label, 1);}
 
 			if ($error) {
 				setEventMessages($langs->trans('ErrorsOnXLines', $error), null, 'errors');

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1988,6 +1988,115 @@ if (empty($reshook)) {
 					$nextSituationInvoice = new Facture($db);
 					$nextSituationInvoice->fetch($id);
 
+					// Get the id of the client order to include
+					$order_to_merge = GETPOST('commandeid', 'int');
+					if (intval($order_to_merge) >= 0) {
+						// We have an order to merge, get it, and its lines
+						$fromElement = 'commande';
+						$fromElementid = $order_to_merge;
+						$parent = new Commande($db);
+						$parent->fetch($fromElementid);
+						$parent->fetch_lines();
+						$importLines = array();
+						foreach ($parent->lines as $line) {
+							$importLines[] = $line->id;
+						}
+
+
+						// COPY OF Import action
+						if (!empty($importLines) && is_array($importLines) && !empty($fromElement) && ctype_alpha($fromElement) && !empty($fromElementid)) {
+							if ($fromElement == 'commande') {
+								dol_include_once('/'.$fromElement.'/class/'.$fromElement.'.class.php');
+								$lineClassName = 'OrderLine';
+								$parent = new Commande($db);
+							} elseif ($fromElement == 'propal') {
+								dol_include_once('/comm/'.$fromElement.'/class/'.$fromElement.'.class.php');
+								$lineClassName = 'PropaleLigne';
+								$parent = new Propal($db);
+							}
+							$nextRang = count($nextSituationInvoice->lines) + 1;
+							$importCount = 0;
+							$error = 0;
+
+							// Add sub-total title
+							if (isset($parent)) {
+								$parent->fetch($fromElementid);
+								$label = '';
+								if ($parent->ref_client) {
+									$label .= $parent->ref_client." - (".$parent->ref.")";
+								} else {
+									$label .= "(".$parent->ref.")";
+								}
+								$sub_tot = new TSubtotal(); 
+								$sub_tot->addTitle($nextSituationInvoice, $label, 1);
+								$nextRang++;
+							}
+
+							// Import lines
+							foreach ($importLines as $lineId) {
+								$lineId = intval($lineId);
+								$originLine = new $lineClassName($db);
+								if (intval($fromElementid) > 0 && $originLine->fetch($lineId) > 0) {
+									$originLine->fetch_optionals();
+									$desc = $originLine->desc;
+									$pu_ht = $originLine->subprice;
+									$qty = $originLine->qty;
+									$txtva = $originLine->tva_tx;
+									$txlocaltax1 = $originLine->localtax1_tx;
+									$txlocaltax2 = $originLine->localtax2_tx;
+									$fk_product = $originLine->fk_product;
+									$remise_percent = $originLine->remise_percent;
+									$date_start = $originLine->date_start;
+									$date_end = $originLine->date_end;
+									$ventil = 0;
+									$info_bits = $originLine->info_bits;
+									$fk_remise_except = $originLine->fk_remise_except;
+									$price_base_type = 'HT';
+									$pu_ttc = 0;
+									$type = $originLine->product_type;
+									$rang = $nextRang++;
+									$special_code = $originLine->special_code;
+									$origin = $originLine->element;
+									$origin_id = $originLine->id;
+									$fk_parent_line = 0;
+									$fk_fournprice = $originLine->fk_fournprice;
+									$pa_ht = $originLine->pa_ht;
+									$label = $originLine->label;
+									$array_options = $originLine->array_options;
+									if ($object->type == Facture::TYPE_SITUATION) {
+										$situation_percent = 0;
+									} else {
+										$situation_percent = 100;
+									}
+									$fk_prev_id = '';
+									$fk_unit = $originLine->fk_unit;
+									$pu_ht_devise = $originLine->multicurrency_subprice;
+
+									$res = $nextSituationInvoice->addline($desc, $pu_ht, $qty, $txtva, $txlocaltax1, $txlocaltax2, $fk_product, $remise_percent, $date_start, $date_end, $ventil, $info_bits, $fk_remise_except, $price_base_type, $pu_ttc, $type, $rang, $special_code, $origin, $origin_id, $fk_parent_line, $fk_fournprice, $pa_ht, $label, $array_options, $situation_percent, $fk_prev_id, $fk_unit, $pu_ht_devise);
+
+									if ($res > 0) {
+										$importCount++;
+									} else {
+										$error++;
+									}
+								} else {
+									$error++;
+								}
+							}
+							
+							// Add sub-total result
+							if (isset($parent)) {$sub_tot->addTotal($nextSituationInvoice, $label, 1);}
+
+							if ($error) {
+								setEventMessages($langs->trans('ErrorsOnXLines', $error), null, 'errors');
+							}
+						}
+					}
+
+
+					// Link added order to created invoice
+					$nextSituationInvoice->add_object_linked($fromElement, $fromElementid, $user);
+					
 					// create extrafields with data from create form
 					$extrafields->fetch_name_optionals_label($nextSituationInvoice->table_element);
 					$ret = $extrafields->setOptionalsFromPost(null, $nextSituationInvoice);
@@ -4087,6 +4196,32 @@ if ($action == 'create') {
 				print '<tr><td>'.$langs->trans('MulticurrencyAmountVAT').'</td><td colspan="2">'.price($objectsrc->multicurrency_total_tva)."</td></tr>";
 				print '<tr><td>'.$langs->trans('MulticurrencyAmountTTC').'</td><td colspan="2">'.price($objectsrc->multicurrency_total_ttc)."</td></tr>";
 			}
+
+			/* 
+			Suggest to link any new order added to the project since the last invoice */
+
+			// First get the previous invoice
+			if ($objectsrc instanceof Facture) {
+			 	$prev_invoice = $objectsrc;
+			} else {
+				$objectsrc->fetchObjectLinked($originid, $origin, '', 'facture');
+				if (isset($objectsrc->linkedObjects['facture']) && is_array($objectsrc->linkedObjects['facture']) && count($objectsrc->linkedObjects['facture']) >= 1) {
+					$prev_invoice = end($objectsrc->linkedObjects['facture']);
+				} else {
+					$prev_invoice = null;
+				}
+			}
+
+			// Then print the box
+			// With no projectid or no prev_invoice, makes no sense
+			if (is_null($projectid)) {
+				dol_syslog('Create new invoice - COUFFIGNAL feat - Pas de chantier lié', LOG_INFO);
+			} elseif (is_null($prev_invoice)) {
+				dol_syslog('Create new invoice - COUFFIGNAL feat - Pas de facture historique', LOG_INFO);
+			} else {
+				print '<tr><td>'.$langs->trans('Avenant à ajouter').'</td><td colspan="2">'.$form->select_new_orders_in_project($projectid, $prev_invoice)."</td></tr>";		
+			}
+			
 		}
 
 		print "</table>\n";

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -10568,6 +10568,117 @@ class Form
 	}
 
 	/**
+	 *  Output a combo list with orders validated linked to the project
+	 *
+	 * @param int $projectid Id of the project to look on
+	 * @param Object $prev_invoice Object of the previous invoice
+	 * @param string $selected Id invoice preselected
+	 * @param string $htmlname Name of HTML select
+	 * @param int $maxlength Maximum length of label
+	 * @param int $option_only Return only html options lines without the select tag
+	 * @param string $show_empty Add an empty line ('1' or string to show for empty line)
+	 * @param int $discard_closed Discard closed projects (0=Keep,1=hide completely,2=Disable)
+	 * @param int $forcefocus Force focus on field (works with javascript only)
+	 * @param int $disabled Disabled
+	 * @param string $morecss More css added to the select component
+	 * @param string $showproject 'all' = Show project info, ''=Hide project info
+	 * @return string            HTML Select Commande
+	 */
+	public function select_new_orders_in_project($projectid, $prev_invoice, $selected = '', $htmlname = 'commandeid', $maxlength = 24, $option_only = 0, $show_empty = '1', $discard_closed = 0, $forcefocus = 0, $disabled = 0, $morecss = 'maxwidth500', $showproject = 'all')
+	{
+		global $user, $conf, $langs;
+
+		require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+
+		$out = '';
+
+		// With no projectid, makes no sense
+		if (is_null($projectid)) {return 'Pas de chantier lié';}
+
+		// With no prev_invoice, makes no sense
+		if (is_null($prev_invoice)) {return 'Pas de facture historique';}
+
+		// Search validated orders in project
+		$sql = "SELECT o.rowid, o.ref, o.ref_client";
+		$sql .= ' FROM ' . $this->db->prefix() . 'commande as o';
+		$sql .= " WHERE o.fk_projet = " .$projectid;
+		$sql .= " AND o.fk_statut=1";
+
+		// Get ids of orders already linkedto previous invoice
+		$prev_invoice->fetchObjectLinked();
+		$already_linked_orders = $prev_invoice->linkedObjectsIds['commande'];
+
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			// Use select2 selector --> HERE
+			if (!empty($conf->use_javascript_ajax)) {
+				include_once DOL_DOCUMENT_ROOT . '/core/lib/ajax.lib.php';
+				$comboenhancement = ajax_combobox($htmlname, '', 0, $forcefocus);
+				$out .= $comboenhancement;
+				$morecss = 'minwidth200imp maxwidth500';
+			}
+
+			if (empty($option_only)) {
+				$out .= '<select class="valignmiddle flat' . ($morecss ? ' ' . $morecss : '') . '"' . ($disabled ? ' disabled="disabled"' : '') . ' id="' . $htmlname . '" name="' . $htmlname . '">';
+			}
+			if (!empty($show_empty)) {
+				$out .= '<option value="0" class="optiongrey">';
+				if (!is_numeric($show_empty)) {
+					$out .= $show_empty;
+				} else {
+					$out .= '&nbsp;';
+				}
+				$out .= '</option>';
+			}
+			$num = $this->db->num_rows($resql);
+			$i = 0;
+
+			// Populate the select
+			if ($num) {
+				while ($i < $num) {
+					$obj = $this->db->fetch_object($resql);
+					// Control for orders already linked
+					if (!in_array($obj->rowid, $already_linked_orders)) {
+						$labeltoshow = $obj->ref. " - ". $obj->ref_client;
+						// Autoselect the first valid
+						if (empty($selected) || $selected == '') {$selected = $obj->rowid;}
+						// Manage selected
+						if (!empty($selected) && $selected == $obj->rowid) {
+							$out .= '<option value="' . $obj->rowid . '" selected';
+							//if ($disabled) $out.=' disabled';						// with select2, field can't be preselected if disabled
+							$out .= '>' . $labeltoshow . '</option>';
+						} else {
+							if ($disabled && ($selected != $obj->rowid)) {
+								$resultat = '';
+							} else {
+								$resultat = '<option value="' . $obj->rowid . '"';
+								if ($disabled) {
+									$resultat .= ' disabled';
+								}
+								$resultat .= '>';
+								$resultat .= $labeltoshow;
+								$resultat .= '</option>';
+							}
+							$out .= $resultat;
+						}
+					}
+					$i++;
+				}
+			}
+			if (empty($option_only)) {
+				$out .= '</select>';
+			}
+
+			$this->db->free($resql);
+
+			return $out;
+		} else {
+			dol_print_error($this->db);
+			return '';
+		}
+	}
+
+	/**
 	 *  Output a combo list with invoices qualified for a third party
 	 *
 	 * @param string $selected Id invoice preselected


### PR DESCRIPTION
NEW Add commande on new situation invoice
If a new commande is added to a project, since the previous situation invoice;
When the new situation invoice is create, the user is prompted to merge the new commande.
![image](https://github.com/user-attachments/assets/7555ac13-2d24-433d-83fb-575eccf5fa85)
If the commande stay selected, it is added on the new situation, with the lines wrapped in a Subtotal.
![image](https://github.com/user-attachments/assets/0cab6486-a6e2-4d81-93e5-1c5d9a68c9af)

## Warning: Needs Subtotal to work. No safe escape.
