### PR TITLE
FIX Change the computation method for progress table in invoice card.php

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5363,6 +5363,7 @@ if ($action == 'create') {
 
 				print '<tr class="oddeven">';
 				print '<td colspan="3" class="right"></td>';
+				print '<td align="center" ></td>';
 				if (isModEnabled("banque")) {
 					print '<td class="right"></td>';
 				}
@@ -5371,6 +5372,19 @@ if ($action == 'create') {
 				print '<td width="18">&nbsp;</td>';
 				print '</tr>';
 			}
+
+			// New line to recap the total price of the situation invoice' serie
+			print '<tr class="oddeven">';
+			print '<td colspan="2" class="left"><b>'.$langs->trans('SituationSerieTotal').'</b></td>';
+			print '<td></td>';
+			print '<td align="center" ></td>';
+			if (isModEnabled("banque")) {
+				print '<td></td>';
+			}
+			print '<td class="right"><b>'.price($object->getLastSituationCompletePrice()).'</b></td>';
+			print '<td class="right"></td>';
+			print '<td width="18">&nbsp;</td>';
+			print '</tr>';
 
 			print '</table>';
 		}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5192,6 +5192,7 @@ if ($action == 'create') {
 					print '<td>'.$next_invoice->getNomUrl(1).'</td>';
 					print '<td></td>';
 					print '<td class="center">'.(($next_invoice->type == Facture::TYPE_CREDIT_NOTE) ? $langs->trans('situationInvoiceShortcode_AS') : $langs->trans('situationInvoiceShortcode_S')).$next_invoice->situation_counter.'</td>';
+					print '<td align="center" >'.$next_invoice->computeMarginalProgress().'%</td>';
 					if (isModEnabled("banque")) {
 						print '<td class="right"></td>';
 					}
@@ -5206,7 +5207,6 @@ if ($action == 'create') {
 
 				print '<tr class="oddeven">';
 				print '<td colspan="3" class="right"></td>';
-				print '<td align="center" >'.$next_invoice->computeMarginalProgress().'%</td>';
 				if (isModEnabled("banque")) {
 					print '<td class="right"></td>';
 				}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2452,23 +2452,22 @@ class Facture extends CommonInvoice
 		$i=0;
 
 		// Loop on all lines
-		foreach ($this->lines as $line)
-		{
-		    if(!class_exists('TSubtotal') || !TSubtotal::isModSubtotalLine($line)){
+		foreach ($this->lines as $line) {
+			if (!class_exists('TSubtotal') || !TSubtotal::isModSubtotalLine($line)) {
 				$divider = $line->situation_percent > 0 ? $line->situation_percent / 100 : 1;
-		        $totalFacture += $line->total_ht / $divider;
-		        $totalAvancement+=$line->total_ht;
-		    }
+				$totalFacture += $line->total_ht / $divider;
+				$totalAvancement+=$line->total_ht;
+			}
 		}
 
 		// Manage error
-		if(!empty($totalFacture)) $avancementGlobal = $totalAvancement / $totalFacture * 100;
+		if (!empty($totalFacture)) $avancementGlobal = $totalAvancement / $totalFacture * 100;
 		else $avancementGlobal = 0;
 
-		return round($avancementGlobal,2);
+		return round($avancementGlobal, 2);
 	}
 
-
+	
 	/** 
 	 * Compute the marginal progress of the invoice.
 	 * Return the 2 digit rounded progress, as percent.

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2437,6 +2437,54 @@ class Facture extends CommonInvoice
 	}
 
 	/**
+	 * Compute the completed price of the invoice, ie. the total price if progress was 100%
+	 * Return the 2 digit rounded price.
+	 *
+	 * @return	float
+	 */
+	public function computeCompletedPrice()
+	{
+		global $conf;
+
+		// Define vars
+		$totalIfCompleted = 0;
+		$i=0;
+
+		// Loop on all lines
+		foreach ($this->lines as $line) {
+			if (!class_exists('TSubtotal') || !TSubtotal::isModSubtotalLine($line)) {
+				// Compute the line price if progress is 100%
+				$totalIfCompleted += ($line->qty * $line->subprice) * (100 - $line->remise_percent) / 100 ;
+			}
+		}
+
+		return round($totalIfCompleted, 2);
+	}
+
+	/**
+	 * Return the completed price of the situation invoice' serie, i.e. the total price if the last situation in the serie was 100%
+	 * Return the 2 digit rounded price.
+	 *
+	 * @return	float
+	 */
+	public function getLastSituationCompletePrice()
+	{
+		global $conf;
+
+		// Load situation invoices before and after this one 
+		$this->fetchPreviousNextSituationInvoice();
+
+		// Get last invoice in the serie
+		if (count($this->tab_next_situation_invoice) > 0) {
+			$last_in_serie = end($this->tab_next_situation_invoice);
+		} else {
+			$last_in_serie = $this;
+		}
+		
+		return $last_in_serie->computeCompletedPrice();
+	}
+
+	/**
 	 * Compute the global progress of the invoice.
 	 * Return the 2 digit rounded progress, as percent.
 	 *
@@ -2447,26 +2495,24 @@ class Facture extends CommonInvoice
 		global $conf;
 
 		// Define vars
-		$totalFacture = 0;
+		$totalIfCompleted = $this->getLastSituationCompletePrice();
 		$totalAvancement = 0;
 		$i=0;
 
 		// Loop on all lines
 		foreach ($this->lines as $line) {
 			if (!class_exists('TSubtotal') || !TSubtotal::isModSubtotalLine($line)) {
-				$divider = $line->situation_percent > 0 ? $line->situation_percent / 100 : 1;
-				$totalFacture += $line->total_ht / $divider;
-				$totalAvancement+=$line->total_ht;
+				// Compute the line price if progress is 100%
+				$totalAvancement += $line->total_ht;
 			}
 		}
 
 		// Manage error
-		if (!empty($totalFacture)) $avancementGlobal = $totalAvancement / $totalFacture * 100;
+		if (!empty($totalIfCompleted)) $avancementGlobal = $totalAvancement / $totalIfCompleted * 100;
 		else $avancementGlobal = 0;
 
 		return round($avancementGlobal, 2);
 	}
-
 	
 	/** 
 	 * Compute the marginal progress of the invoice.

--- a/htdocs/langs/en_US/compta.lang
+++ b/htdocs/langs/en_US/compta.lang
@@ -312,3 +312,4 @@ InvoiceToPay30Days=To pay (> 30 days)
 ConfirmPreselectAccount=Preselect accountancy code
 ConfirmPreselectAccountQuestion=Are you sure you want to preselect the %s selected lines with this accountancy code ?
 AmountPaidMustMatchAmountOfDownPayment=Amount paid must match amount of down payment
+SituationSerieTotal=Total amount contract


### PR DESCRIPTION
# FIX Change the computation method for progress table in invoice card.php
The global progress of an invoice used to be computed on the grand total (assuming 100% progress) of the invoice itself.
Now, we use the grand total of the last invoice in the situation serie.
This behavioural change is made to feat to industry practice (BTP in France).