### PR TITLE
FIX - UNIT ALWAYS DISPLAYED ON LINE CREATION

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -1263,7 +1263,7 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 		<?php } ?>
 		/* jQuery("#tva_tx, #title_vat").hide(); */
 		/* jQuery("#title_fourn_ref").hide(); */
-		jQuery("#np_marginRate, #np_markRate, .np_marginRate, .np_markRate, #units, #title_units").hide();
+		jQuery("#np_marginRate, #np_markRate, .np_marginRate, .np_markRate").hide();
 		jQuery("#buying_price").show();
 		jQuery('#trlinefordates, .divlinefordates').show();
 	}


### PR DESCRIPTION
# FIX|Fix #16 
this fix make always displayed units even when working with predifined product/service
