### PR TITLE
save unit value on insert

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -794,7 +794,11 @@ class Propal extends CommonObject
 			$this->line->total_ttc = (float) $total_ttc;
 			$this->line->special_code = $special_code;
 			$this->line->fk_parent_line = $fk_parent_line;
-			$this->line->fk_unit = $fk_unit;
+			if (isset($_POST['units'])) {
+				$this->line->fk_unit = $_POST['units'];
+			} else {
+				$this->line->fk_unit = $fk_unit;
+			}
 
 			$this->line->date_start = $date_start;
 			$this->line->date_end = $date_end;

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1735,7 +1735,11 @@ class Commande extends CommonOrder
 			$this->line->origin = $origin;
 			$this->line->origin_id = $origin_id;
 			$this->line->fk_parent_line = $fk_parent_line;
-			$this->line->fk_unit = $fk_unit;
+			if (isset($_POST['units'])) {
+				$this->line->fk_unit = $_POST['units'];
+			} else {
+				$this->line->fk_unit = $fk_unit;
+			}
 
 			$this->line->date_start = $date_start;
 			$this->line->date_end = $date_end;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4100,7 +4100,11 @@ class Facture extends CommonInvoice
 			$this->line->origin_id = $origin_id;
 			$this->line->situation_percent = $situation_percent;
 			$this->line->fk_prev_id = $fk_prev_id;
-			$this->line->fk_unit = $fk_unit;
+			if (isset($_POST['units'])) {
+				$this->line->fk_unit = $_POST['units'];
+			} else {
+				$this->line->fk_unit = $fk_unit;
+			}
 
 			// infos margin
 			$this->line->fk_fournprice = $fk_fournprice;

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2219,7 +2219,11 @@ class CommandeFournisseur extends CommonOrder
 			$this->line->origin = $origin;
 			$this->line->origin_type = $origin;
 			$this->line->origin_id = $origin_id;
-			$this->line->fk_unit = $fk_unit;
+			if (isset($_POST['units'])) {
+				$this->line->fk_unit = $_POST['units'];
+			} else {
+				$this->line->fk_unit = $fk_unit;
+			}
 
 			$this->line->date_start = $date_start;
 			$this->line->date_end = $date_end;

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2286,7 +2286,11 @@ class FactureFournisseur extends CommonInvoice
 			$supplierinvoiceline->fk_parent_line = $fk_parent_line;
 			$supplierinvoiceline->origin = $this->origin;
 			$supplierinvoiceline->origin_id = $origin_id;
-			$supplierinvoiceline->fk_unit = $fk_unit;
+			if (isset($_POST['units'])) {
+				$supplierinvoiceline->fk_unit = $_POST['units'];
+			} else {
+				$supplierinvoiceline->fk_unit = $fk_unit;
+			}
 
 			// Multicurrency
 			$supplierinvoiceline->fk_multicurrency = $this->fk_multicurrency;

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -629,7 +629,11 @@ class SupplierProposal extends CommonObject
 			$this->line->product_type = $type;
 			$this->line->special_code = $special_code;
 			$this->line->fk_parent_line = $fk_parent_line;
-			$this->line->fk_unit = $fk_unit;
+			if (isset($_POST['units'])) {
+				$this->line->fk_unit = $_POST['units'];
+			} else {
+				$this->line->fk_unit = $fk_unit;
+			}
 			$this->line->origin = $origin;
 			$this->line->origin_id = $origin_id;
 			$this->line->ref_fourn = $this->db->escape($ref_supplier);


### PR DESCRIPTION
FIX #16 Units: Can change units once set
**Description**
Cette pull request traite le problème où la valeur de l'unité n'était pas enregistrée lors de l'insertion. Pour résoudre ce problème, des modifications ont été apportées aux fichiers principaux afin de garantir que la valeur de l'unité est sauvegardée lors de l'insertion d'une ligne.
**Modifications**
Les fichiers core suivants ont été mis à jour pour gérer correctement la valeur de l'unité :
htdocs/comm/propal/class/propal.class.php
htdocs/commande/class/commande.class.php
htdocs/compta/facture/class/facture.class.php
htdocs/fourn/class/fournisseur.commande.class.php
htdocs/fourn/class/fournisseur.facture.class.php
htdocs/supplier_proposal/class/supplier_proposal.class.php
