### PR TITLE
FEAT Auto nameing facture

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3322,6 +3322,9 @@ if ($action == 'create') {
 
 			$projectid = (!empty($projectid) ? $projectid : $objectsrc->fk_project);
 			$ref_client = (!empty($objectsrc->ref_client) ? $objectsrc->ref_client : (!empty($objectsrc->ref_customer) ? $objectsrc->ref_customer : ''));
+			// -- Hook Couffignal
+			$ref_client = 'S' . $objectsrc->situation_cycle_ref + 1;
+			// --
 
 			// only if socid not filled else it's allready done upper
 			if (empty($socid)) {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5465,7 +5465,7 @@ if ($action == 'create') {
 				print '</tr>';
 			}
 
-			// New line to recap the total price of the situation invoice' serie
+			// New line to recap the total price of the situation invoice' series
 			print '<tr class="oddeven">';
 			print '<td colspan="2" class="left"><b>'.$langs->trans('SituationSerieTotal').'</b></td>';
 			print '<td></td>';

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3323,7 +3323,7 @@ if ($action == 'create') {
 			$projectid = (!empty($projectid) ? $projectid : $objectsrc->fk_project);
 			$ref_client = (!empty($objectsrc->ref_client) ? $objectsrc->ref_client : (!empty($objectsrc->ref_customer) ? $objectsrc->ref_customer : ''));
 			// -- Hook Couffignal
-			$ref_client = 'S' . $objectsrc->situation_cycle_ref + 1;
+			$ref_client = 'S' . $objectsrc->situation_counter + 1;
 			// --
 
 			// only if socid not filled else it's allready done upper

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1,24 +1,24 @@
 <?php
-/* Copyright (C) 2002-2007  Rodolphe Quiedeville    <rodolphe@quiedeville.org>
- * Copyright (C) 2004-2013  Laurent Destailleur     <eldy@users.sourceforge.net>
- * Copyright (C) 2004       Sebastien Di Cintio     <sdicintio@ressource-toi.org>
- * Copyright (C) 2004       Benoit Mortier          <benoit.mortier@opensides.be>
- * Copyright (C) 2005       Marc Barilley / Ocebo   <marc@ocebo.com>
- * Copyright (C) 2005-2014  Regis Houssin           <regis.houssin@inodbox.com>
- * Copyright (C) 2006       Andre Cianfarani        <acianfa@free.fr>
- * Copyright (C) 2007       Franky Van Liedekerke   <franky.van.liedekerke@telenet.be>
- * Copyright (C) 2010-2020  Juanjo Menent           <jmenent@2byte.es>
- * Copyright (C) 2012-2014  Christophe Battarel     <christophe.battarel@altairis.fr>
- * Copyright (C) 2012-2015  Marcos García           <marcosgdf@gmail.com>
- * Copyright (C) 2012       Cédric Salvador         <csalvador@gpcsolutions.fr>
- * Copyright (C) 2012-2014  Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
- * Copyright (C) 2013       Cedric Gross            <c.gross@kreiz-it.fr>
- * Copyright (C) 2013       Florian Henry           <florian.henry@open-concept.pro>
- * Copyright (C) 2016-2022  Ferran Marcet           <fmarcet@2byte.es>
+/* Copyright (C) 2002-2007  Rodolphe Quiedeville	<rodolphe@quiedeville.org>
+ * Copyright (C) 2004-2013  Laurent Destailleur	 <eldy@users.sourceforge.net>
+ * Copyright (C) 2004	   Sebastien Di Cintio	 <sdicintio@ressource-toi.org>
+ * Copyright (C) 2004	   Benoit Mortier		  <benoit.mortier@opensides.be>
+ * Copyright (C) 2005	   Marc Barilley / Ocebo   <marc@ocebo.com>
+ * Copyright (C) 2005-2014  Regis Houssin		   <regis.houssin@inodbox.com>
+ * Copyright (C) 2006	   Andre Cianfarani		<acianfa@free.fr>
+ * Copyright (C) 2007	   Franky Van Liedekerke   <franky.van.liedekerke@telenet.be>
+ * Copyright (C) 2010-2020  Juanjo Menent		   <jmenent@2byte.es>
+ * Copyright (C) 2012-2014  Christophe Battarel	 <christophe.battarel@altairis.fr>
+ * Copyright (C) 2012-2015  Marcos García		   <marcosgdf@gmail.com>
+ * Copyright (C) 2012	   Cédric Salvador		 <csalvador@gpcsolutions.fr>
+ * Copyright (C) 2012-2014  Raphaël Doursenaud	  <rdoursenaud@gpcsolutions.fr>
+ * Copyright (C) 2013	   Cedric Gross			<c.gross@kreiz-it.fr>
+ * Copyright (C) 2013	   Florian Henry		   <florian.henry@open-concept.pro>
+ * Copyright (C) 2016-2022  Ferran Marcet		   <fmarcet@2byte.es>
  * Copyright (C) 2018-2022  Alexandre Spangaro		<aspangaro@open-dsi.fr>
- * Copyright (C) 2018       Nicolas ZABOURI         <info@inovea-conseil.com>
- * Copyright (C) 2022       Sylvain Legrand         <contact@infras.fr>
- * Copyright (C) 2023      	Gauthier VERDOL       	<gauthier.verdol@atm-consulting.fr>
+ * Copyright (C) 2018	   Nicolas ZABOURI		 <info@inovea-conseil.com>
+ * Copyright (C) 2022	   Sylvain Legrand		 <contact@infras.fr>
+ * Copyright (C) 2023	  	Gauthier VERDOL	   	<gauthier.verdol@atm-consulting.fr>
  * Copyright (C) 2023		Nick Fragoulis
  *
  * This program is free software; you can redistribute it and/or modify
@@ -36,9 +36,9 @@
  */
 
 /**
- *	\file       htdocs/compta/facture/class/facture.class.php
- *	\ingroup    facture
- *	\brief      File of class to manage invoices
+ *	\file	   htdocs/compta/facture/class/facture.class.php
+ *	\ingroup	facture
+ *	\brief	  File of class to manage invoices
  */
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/commoninvoice.class.php';
@@ -71,7 +71,7 @@ class Facture extends CommonInvoice
 	public $table_element = 'facture';
 
 	/**
-	 * @var string    Name of subtable line
+	 * @var string	Name of subtable line
 	 */
 	public $table_element_line = 'facturedet';
 
@@ -159,10 +159,10 @@ class Facture extends CommonInvoice
 
 	public $total_ht; /* To be changed with PHP8.4 support {
 		set {
-            // Get rate before changing total to update discount with new total
-            $this->prorata_discount = $value * $this->prorata_rate; // Silently update prorata discount on total change
-            $this->total_ht = $value;
-        }
+			// Get rate before changing total to update discount with new total
+			$this->prorata_discount = $value * $this->prorata_rate; // Silently update prorata discount on total change
+			$this->total_ht = $value;
+		}
 	}*/
 	public $total_tva;
 	public $total_localtax1;
@@ -257,12 +257,12 @@ class Facture extends CommonInvoice
 	public $retained_warranty_fk_cond_reglement;
 
 	/**
-	 * @var double amount to be retained on payment and used as a charge 
+	 * @var double amount to be retained on payment and used as a charge
 	 */
 	public $prorata_discount = 0;
 
 	/**
-	 * @var double percent (0 to 100) to be retained on payment and used as a charge 
+	 * @var double percent (0 to 100) to be retained on payment and used as a charge
 	 * WARNING: DO NOT SET DIRECTlY, until PHP8.4 property hooks are in place
 	 */
 	public $prorata_rate;
@@ -272,15 +272,15 @@ class Facture extends CommonInvoice
 	 * var percent of prorata_discount compared to total_ht
 	 */
 	/*public double $prorata_rate;  For PHP8.4 = {
-        get {
-        	if (isset($this->total_ht) && $this->total_ht != 0) {
-        		return $this->$prorata_discount / $this->total_ht;
-        	} else { return -1; }
-        }
-        set {
-            $this->prorata_discount = $value * $this->total_ht;
-        }
-    }*/
+		get {
+			if (isset($this->total_ht) && $this->total_ht != 0) {
+				return $this->$prorata_discount / $this->total_ht;
+			} else { return -1; }
+		}
+		set {
+			$this->prorata_discount = $value * $this->total_ht;
+		}
+	}*/
 
 	/**
 	 * @var int availabilty ID
@@ -302,7 +302,7 @@ class Facture extends CommonInvoice
 
 	/**
 	 *  'type' if the field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter]]', 'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'html', 'date', 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')
-	 *         Note: Filter can be a string like "(t.ref:like:'SO-%') or (t.date_creation:<:'20160101') or (t.nature:is:NULL)"
+	 *		 Note: Filter can be a string like "(t.ref:like:'SO-%') or (t.date_creation:<:'20160101') or (t.nature:is:NULL)"
 	 *  'label' the translation key.
 	 *  'enabled' is a condition when the field must be managed.
 	 *  'position' is the sort order of field.
@@ -477,7 +477,7 @@ class Facture extends CommonInvoice
 	 *  Note: this->ref can be set or empty. If empty, we will use "(PROV999)"
 	 *  Note: this->fac_rec must be set to create invoice from a recurring invoice
 	 *
-	 *	@param	User	$user      		Object user that create
+	 *	@param	User	$user	  		Object user that create
 	 *	@param  int		$notrigger		1=Does not execute triggers, 0 otherwise
 	 * 	@param	int		$forceduedate	If set, do not recalculate due date from payment condition but force it with value
 	 *	@return	int						Return integer <0 if KO, >0 if OK
@@ -570,24 +570,24 @@ class Facture extends CommonInvoice
 			if (!empty($_facrec->frequency)) {  // Invoice are created on same thirdparty than template when there is a recurrence, but not necessarly when there is no recurrence.
 				$this->socid = $_facrec->socid;
 			}
-			$this->entity            = $_facrec->entity; // Invoice created in same entity than template
+			$this->entity			= $_facrec->entity; // Invoice created in same entity than template
 
 			// Fields coming from GUI (priority on template). TODO Value of template should be used as default value on GUI so we can use here always value from GUI
-			$this->fk_project        = GETPOST('projectid', 'int') > 0 ? ((int) GETPOST('projectid', 'int')) : $_facrec->fk_project;
-			$this->note_public       = GETPOSTISSET('note_public') ? GETPOST('note_public', 'restricthtml') : $_facrec->note_public;
-			$this->note_private      = GETPOSTISSET('note_private') ? GETPOST('note_private', 'restricthtml') : $_facrec->note_private;
+			$this->fk_project		= GETPOST('projectid', 'int') > 0 ? ((int) GETPOST('projectid', 'int')) : $_facrec->fk_project;
+			$this->note_public	   = GETPOSTISSET('note_public') ? GETPOST('note_public', 'restricthtml') : $_facrec->note_public;
+			$this->note_private	  = GETPOSTISSET('note_private') ? GETPOST('note_private', 'restricthtml') : $_facrec->note_private;
 			$this->model_pdf = GETPOSTISSET('model') ? GETPOST('model', 'alpha') : $_facrec->model_pdf;
 			$this->cond_reglement_id = GETPOST('cond_reglement_id', 'int') > 0 ? ((int) GETPOST('cond_reglement_id', 'int')) : $_facrec->cond_reglement_id;
 			$this->mode_reglement_id = GETPOST('mode_reglement_id', 'int') > 0 ? ((int) GETPOST('mode_reglement_id', 'int')) : $_facrec->mode_reglement_id;
-			$this->fk_account        = GETPOST('fk_account') > 0 ? ((int) GETPOST('fk_account')) : $_facrec->fk_account;
+			$this->fk_account		= GETPOST('fk_account') > 0 ? ((int) GETPOST('fk_account')) : $_facrec->fk_account;
 
 			// Set here to have this defined for substitution into notes, should be recalculated after adding lines to get same result
-			$this->total_ht          = $_facrec->total_ht;
-			$this->total_ttc         = $_facrec->total_ttc;
+			$this->total_ht		  = $_facrec->total_ht;
+			$this->total_ttc		 = $_facrec->total_ttc;
 
 			// Fields always coming from template
-			//$this->remise_absolue    = $_facrec->remise_absolue;
-			//$this->remise_percent    = $_facrec->remise_percent;	// TODO deprecated
+			//$this->remise_absolue	= $_facrec->remise_absolue;
+			//$this->remise_percent	= $_facrec->remise_percent;	// TODO deprecated
 			$this->fk_incoterms = $_facrec->fk_incoterms;
 			$this->location_incoterms = $_facrec->location_incoterms;
 
@@ -765,7 +765,7 @@ class Facture extends CommonInvoice
 			// Add object linked
 			if (!$error && $this->id && !empty($this->linked_objects) && is_array($this->linked_objects)) {
 				foreach ($this->linked_objects as $origin => $tmp_origin_id) {
-					if (is_array($tmp_origin_id)) {       // New behaviour, if linked_object can have several links per type, so is something like array('contract'=>array(id1, id2, ...))
+					if (is_array($tmp_origin_id)) {	   // New behaviour, if linked_object can have several links per type, so is something like array('contract'=>array(id1, id2, ...))
 						foreach ($tmp_origin_id as $origin_id) {
 							$ret = $this->add_object_linked($origin, $origin_id);
 							if (!$ret) {
@@ -788,7 +788,7 @@ class Facture extends CommonInvoice
 			if (!$error && $this->id && getDolGlobalString('MAIN_PROPAGATE_CONTACTS_FROM_ORIGIN') && !empty($this->origin) && !empty($this->origin_id)) {   // Get contact from origin object
 				$originforcontact = $this->origin;
 				$originidforcontact = $this->origin_id;
-				if ($originforcontact == 'shipping') {     // shipment and order share the same contacts. If creating from shipment we take data of order
+				if ($originforcontact == 'shipping') {	 // shipment and order share the same contacts. If creating from shipment we take data of order
 					require_once DOL_DOCUMENT_ROOT.'/expedition/class/expedition.class.php';
 					$exp = new Expedition($this->db);
 					$exp->fetch($this->origin_id);
@@ -1156,7 +1156,7 @@ class Facture extends CommonInvoice
 	/**
 	 *	Create a new invoice in database from current invoice
 	 *
-	 *	@param      User	$user    		Object user that ask creation
+	 *	@param	  User	$user			Object user that ask creation
 	 *	@param		int		$invertdetail	Reverse sign of amounts for lines
 	 *	@return		int						Return integer <0 if KO, >0 if OK
 	 */
@@ -1180,24 +1180,24 @@ class Facture extends CommonInvoice
 		}
 
 		$facture->fk_facture_source = $this->fk_facture_source;
-		$facture->type 			    = $this->type;
+		$facture->type 				= $this->type;
 		$facture->subtype 			= $this->subtype;
-		$facture->socid 		    = $this->socid;
-		$facture->date              = $this->date;
+		$facture->socid 			= $this->socid;
+		$facture->date			  = $this->date;
 		$facture->date_pointoftax   = $this->date_pointoftax;
-		$facture->note_public       = $this->note_public;
-		$facture->note_private      = $this->note_private;
-		$facture->ref_client        = $this->ref_client;
-		$facture->model_pdf         = $this->model_pdf;
-		$facture->fk_project        = $this->fk_project;
+		$facture->note_public	   = $this->note_public;
+		$facture->note_private	  = $this->note_private;
+		$facture->ref_client		= $this->ref_client;
+		$facture->model_pdf		 = $this->model_pdf;
+		$facture->fk_project		= $this->fk_project;
 		$facture->cond_reglement_id = $this->cond_reglement_id;
 		$facture->mode_reglement_id = $this->mode_reglement_id;
-		//$facture->remise_absolue    = $this->remise_absolue;
-		//$facture->remise_percent    = $this->remise_percent;	// TODO deprecated
+		//$facture->remise_absolue	= $this->remise_absolue;
+		//$facture->remise_percent	= $this->remise_percent;	// TODO deprecated
 
-		$facture->origin            = $this->origin;
-		$facture->origin_id         = $this->origin_id;
-		$facture->fk_account         = $this->fk_account;
+		$facture->origin			= $this->origin;
+		$facture->origin_id		 = $this->origin_id;
+		$facture->fk_account		 = $this->fk_account;
 
 		$facture->lines = $this->lines; // Array of lines of invoice
 		$facture->situation_counter = $this->situation_counter;
@@ -1252,9 +1252,9 @@ class Facture extends CommonInvoice
 	/**
 	 *	Load an object from its id and create a new one in database
 	 *
-	 *	@param      User	$user        	User that clone
-	 *  @param  	int 	$fromid         Id of object to clone
-	 * 	@return		int					    New id of clone
+	 *	@param	  User	$user			User that clone
+	 *  @param  	int 	$fromid		 Id of object to clone
+	 * 	@return		int						New id of clone
 	 */
 	public function createFromClone(User $user, $fromid = 0)
 	{
@@ -1291,18 +1291,18 @@ class Facture extends CommonInvoice
 		$object->status = self::STATUS_DRAFT;
 
 		// Clear fields
-		$object->date               = (empty($this->date) ? dol_now() : $this->date);
+		$object->date			   = (empty($this->date) ? dol_now() : $this->date);
 		$object->user_creation_id   = $user->id;
 		$object->user_validation_id = null;
-		$object->fk_user_author     = $user->id;
-		$object->fk_user_valid      = null;
+		$object->fk_user_author	 = $user->id;
+		$object->fk_user_valid	  = null;
 		$object->fk_facture_source  = 0;
-		$object->date_creation      = '';
+		$object->date_creation	  = '';
 		$object->date_modification = '';
-		$object->date_validation    = '';
-		$object->ref_client         = '';
-		$object->close_code         = '';
-		$object->close_note         = '';
+		$object->date_validation	= '';
+		$object->ref_client		 = '';
+		$object->close_code		 = '';
+		$object->close_note		 = '';
 		if (getDolGlobalInt('MAIN_DONT_KEEP_NOTE_ON_CLONING') == 1) {
 			$object->note_private = '';
 			$object->note_public = '';
@@ -1393,9 +1393,9 @@ class Facture extends CommonInvoice
 	/**
 	 *  Load an object from an order and create a new invoice into database
 	 *
-	 *  @param      Object			$object         	Object source
+	 *  @param	  Object			$object		 	Object source
 	 *  @param		User			$user				Object user
-	 *  @return     int             					Return integer <0 if KO, 0 if nothing done, 1 if OK
+	 *  @return	 int			 					Return integer <0 if KO, 0 if nothing done, 1 if OK
 	 */
 	public function createFromOrder($object, User $user)
 	{
@@ -1458,17 +1458,17 @@ class Facture extends CommonInvoice
 			$this->lines[$i] = $line;
 		}
 
-		$this->socid                = $object->socid;
-		$this->fk_project           = $object->fk_project;
+		$this->socid				= $object->socid;
+		$this->fk_project		   = $object->fk_project;
 		$this->fk_account = $object->fk_account;
-		$this->cond_reglement_id    = $object->cond_reglement_id;
-		$this->mode_reglement_id    = $object->mode_reglement_id;
-		$this->availability_id      = $object->availability_id;
-		$this->demand_reason_id     = $object->demand_reason_id;
-		$this->delivery_date        = $object->delivery_date;
+		$this->cond_reglement_id	= $object->cond_reglement_id;
+		$this->mode_reglement_id	= $object->mode_reglement_id;
+		$this->availability_id	  = $object->availability_id;
+		$this->demand_reason_id	 = $object->demand_reason_id;
+		$this->delivery_date		= $object->delivery_date;
 		$this->fk_delivery_address  = $object->fk_delivery_address; // deprecated
-		$this->contact_id           = $object->contact_id;
-		$this->ref_client           = $object->ref_client;
+		$this->contact_id		   = $object->contact_id;
+		$this->ref_client		   = $object->ref_client;
 
 		if (!getDolGlobalString('MAIN_DISABLE_PROPAGATE_NOTES_FROM_ORIGIN')) {
 			$this->note_private = $object->note_private;
@@ -1522,10 +1522,10 @@ class Facture extends CommonInvoice
 	/**
 	 *  Load an object from an order and create a new invoice into database
 	 *
-	 *  @param      Object			$object         	Object source
+	 *  @param	  Object			$object		 	Object source
 	 *  @param		User			$user				Object user
 	 * 	@param		array			$lines				Ids of lines to use for invoice. If empty, all lines will be used.
-	 *  @return     int             					Return integer <0 if KO, 0 if nothing done, 1 if OK
+	 *  @return	 int			 					Return integer <0 if KO, 0 if nothing done, 1 if OK
 	 */
 	public function createFromContract($object, User $user, $lines = array())
 	{
@@ -1593,17 +1593,17 @@ class Facture extends CommonInvoice
 			$this->lines[$i] = $line;
 		}
 
-		$this->socid                = $object->socid;
-		$this->fk_project           = $object->fk_project;
+		$this->socid				= $object->socid;
+		$this->fk_project		   = $object->fk_project;
 		$this->fk_account = $object->fk_account;
-		$this->cond_reglement_id    = $object->cond_reglement_id;
-		$this->mode_reglement_id    = $object->mode_reglement_id;
-		$this->availability_id      = $object->availability_id;
-		$this->demand_reason_id     = $object->demand_reason_id;
-		$this->delivery_date        = $object->delivery_date;
+		$this->cond_reglement_id	= $object->cond_reglement_id;
+		$this->mode_reglement_id	= $object->mode_reglement_id;
+		$this->availability_id	  = $object->availability_id;
+		$this->demand_reason_id	 = $object->demand_reason_id;
+		$this->delivery_date		= $object->delivery_date;
 		$this->fk_delivery_address  = $object->fk_delivery_address; // deprecated
-		$this->contact_id           = $object->contact_id;
-		$this->ref_client           = $object->ref_client;
+		$this->contact_id		   = $object->contact_id;
+		$this->ref_client		   = $object->ref_client;
 
 		if (!getDolGlobalString('MAIN_DISABLE_PROPAGATE_NOTES_FROM_ORIGIN')) {
 			$this->note_private = $object->note_private;
@@ -2012,16 +2012,16 @@ class Facture extends CommonInvoice
 	/**
 	 *  Return clicable link of object (with eventually picto)
 	 *
-	 *  @param	int		$withpicto       			Add picto into link
-	 *  @param  string	$option          			Where point the link
-	 *  @param  int		$max             			Maxlength of ref
-	 *  @param  int		$short           			1=Return just URL
-	 *  @param  string  $moretitle       			Add more text to title tooltip
+	 *  @param	int		$withpicto	   			Add picto into link
+	 *  @param  string	$option		  			Where point the link
+	 *  @param  int		$max			 			Maxlength of ref
+	 *  @param  int		$short		   			1=Return just URL
+	 *  @param  string  $moretitle	   			Add more text to title tooltip
 	 *  @param	int  	$notooltip		 			1=Disable tooltip
-	 *  @param  int     $addlinktonotes  			1=Add link to notes
-	 *  @param  int     $save_lastsearch_value		-1=Auto, 0=No save of lastsearch_values when clicking, 1=Save lastsearch_values whenclicking
-	 *  @param  string  $target                     Target of link ('', '_self', '_blank', '_parent', '_backoffice', ...)
-	 *  @return string 			         			String with URL
+	 *  @param  int	 $addlinktonotes  			1=Add link to notes
+	 *  @param  int	 $save_lastsearch_value		-1=Auto, 0=No save of lastsearch_values when clicking, 1=Save lastsearch_values whenclicking
+	 *  @param  string  $target					 Target of link ('', '_self', '_blank', '_parent', '_backoffice', ...)
+	 *  @return string 					 			String with URL
 	 */
 	public function getNomUrl($withpicto = 0, $option = '', $max = 0, $short = 0, $moretitle = '', $notooltip = 0, $addlinktonotes = 0, $save_lastsearch_value = -1, $target = '')
 	{
@@ -2143,12 +2143,12 @@ class Facture extends CommonInvoice
 	/**
 	 *	Get object from database. Get also lines.
 	 *
-	 *	@param      int		$rowid       		Id of object to load
+	 *	@param	  int		$rowid	   		Id of object to load
 	 * 	@param		string	$ref				Reference of invoice
 	 * 	@param		string	$ref_ext			External reference of invoice
 	 * 	@param		int		$notused			Not used
 	 *  @param		bool	$fetch_situation	Load also the previous and next situation invoice into $tab_previous_situation_invoice and $tab_next_situation_invoice
-	 *	@return     int         				>0 if OK, <0 if KO, 0 if not found
+	 *	@return	 int		 				>0 if OK, <0 if KO, 0 if not found
 	 */
 	public function fetch($rowid, $ref = '', $ref_ext = '', $notused = 0, $fetch_situation = false)
 	{
@@ -2210,17 +2210,17 @@ class Facture extends CommonInvoice
 				$this->subtype				= $obj->subtype;
 				$this->date					= $this->db->jdate($obj->df);
 				$this->date_pointoftax		= $this->db->jdate($obj->date_pointoftax);
-				$this->date_creation        = $this->db->jdate($obj->datec);
+				$this->date_creation		= $this->db->jdate($obj->datec);
 				$this->date_validation		= $this->db->jdate($obj->datev);
-				$this->date_modification    = $this->db->jdate($obj->datem);
-				$this->datem                = $this->db->jdate($obj->datem);
+				$this->date_modification	= $this->db->jdate($obj->datem);
+				$this->datem				= $this->db->jdate($obj->datem);
 				$this->total_ht				= $obj->total_ht;
 				$this->total_tva			= $obj->total_tva;
 				$this->total_localtax1		= $obj->localtax1;
 				$this->total_localtax2		= $obj->localtax2;
 				$this->total_ttc			= $obj->total_ttc;
-				$this->revenuestamp         = $obj->revenuestamp;
-				$this->paye                 = $obj->paye;
+				$this->revenuestamp		 = $obj->revenuestamp;
+				$this->paye				 = $obj->paye;
 				$this->close_code			= $obj->close_code;
 				$this->close_note			= $obj->close_note;
 
@@ -2247,19 +2247,19 @@ class Facture extends CommonInvoice
 				$this->note = $obj->note_private; // deprecated
 				$this->note_private = $obj->note_private;
 				$this->note_public			= $obj->note_public;
-				$this->user_creation_id     = $obj->fk_user_author;
+				$this->user_creation_id	 = $obj->fk_user_author;
 				$this->user_validation_id   = $obj->fk_user_valid;
 				$this->user_modification_id = $obj->fk_user_modif;
-				$this->fk_user_author       = $obj->fk_user_author;
-				$this->fk_user_valid        = $obj->fk_user_valid;
-				$this->fk_user_modif        = $obj->fk_user_modif;
+				$this->fk_user_author	   = $obj->fk_user_author;
+				$this->fk_user_valid		= $obj->fk_user_valid;
+				$this->fk_user_modif		= $obj->fk_user_modif;
 				$this->model_pdf = $obj->model_pdf;
 				$this->last_main_doc = $obj->last_main_doc;
 				$this->situation_cycle_ref  = $obj->situation_cycle_ref;
-				$this->situation_counter    = $obj->situation_counter;
-				$this->situation_final      = $obj->situation_final;
-				$this->retained_warranty    = $obj->retained_warranty;
-				$this->retained_warranty_date_limit         = $this->db->jdate($obj->retained_warranty_date_limit);
+				$this->situation_counter	= $obj->situation_counter;
+				$this->situation_final	  = $obj->situation_final;
+				$this->retained_warranty	= $obj->retained_warranty;
+				$this->retained_warranty_date_limit		 = $this->db->jdate($obj->retained_warranty_date_limit);
 				$this->retained_warranty_fk_cond_reglement  = $obj->retained_warranty_fk_cond_reglement;
 				$this->prorata_discount		= $obj->prorata_discount;
 				$this->prorata_rate			= $obj->total_ht != 0 ? $obj->prorata_discount / $obj->total_ht * 100 : 0;
@@ -2267,7 +2267,7 @@ class Facture extends CommonInvoice
 				$this->extraparams = !empty($obj->extraparams) ? (array) json_decode($obj->extraparams, true) : array();
 
 				//Incoterms
-				$this->fk_incoterms         = $obj->fk_incoterms;
+				$this->fk_incoterms		 = $obj->fk_incoterms;
 				$this->location_incoterms   = $obj->location_incoterms;
 				$this->label_incoterms = $obj->label_incoterms;
 
@@ -2322,7 +2322,7 @@ class Facture extends CommonInvoice
 	 *	@param		int		$only_product	Return only physical products
 	 *	@param		int		$loadalsotranslation	Return translation for products
 	 *
-	 *	@return     int         1 if OK, < 0 if KO
+	 *	@return	 int		 1 if OK, < 0 if KO
 	 */
 	public function fetch_lines($only_product = 0, $loadalsotranslation = 0)
 	{
@@ -2352,41 +2352,41 @@ class Facture extends CommonInvoice
 				$objp = $this->db->fetch_object($result);
 				$line = new FactureLigne($this->db);
 
-				$line->id               = $objp->rowid;
+				$line->id			   = $objp->rowid;
 				$line->rowid = $objp->rowid; // deprecated
-				$line->fk_facture       = $objp->fk_facture;
-				$line->label            = $objp->custom_label; // deprecated
-				$line->desc             = $objp->description; // Description line
-				$line->description      = $objp->description; // Description line
-				$line->product_type     = $objp->product_type; // Type of line
-				$line->ref              = $objp->product_ref; // Ref product
-				$line->product_ref      = $objp->product_ref; // Ref product
-				$line->libelle          = $objp->product_label; // deprecated
+				$line->fk_facture	   = $objp->fk_facture;
+				$line->label			= $objp->custom_label; // deprecated
+				$line->desc			 = $objp->description; // Description line
+				$line->description	  = $objp->description; // Description line
+				$line->product_type	 = $objp->product_type; // Type of line
+				$line->ref			  = $objp->product_ref; // Ref product
+				$line->product_ref	  = $objp->product_ref; // Ref product
+				$line->libelle		  = $objp->product_label; // deprecated
 				$line->product_label 	= $objp->product_label; // Label product
 				$line->product_barcode  = $objp->product_barcode; // Barcode number product
-				$line->product_desc     = $objp->product_desc; // Description product
+				$line->product_desc	 = $objp->product_desc; // Description product
 				$line->fk_product_type  = $objp->fk_product_type; // Type of product
-				$line->qty              = $objp->qty;
-				$line->subprice         = $objp->subprice;
-				$line->ref_ext          = $objp->ref_ext; // line external ref
+				$line->qty			  = $objp->qty;
+				$line->subprice		 = $objp->subprice;
+				$line->ref_ext		  = $objp->ref_ext; // line external ref
 
 				$line->vat_src_code = $objp->vat_src_code;
-				$line->tva_tx           = $objp->tva_tx;
-				$line->localtax1_tx     = $objp->localtax1_tx;
-				$line->localtax2_tx     = $objp->localtax2_tx;
+				$line->tva_tx		   = $objp->tva_tx;
+				$line->localtax1_tx	 = $objp->localtax1_tx;
+				$line->localtax2_tx	 = $objp->localtax2_tx;
 				$line->localtax1_type   = $objp->localtax1_type;
 				$line->localtax2_type   = $objp->localtax2_type;
 				$line->remise_percent   = $objp->remise_percent;
 				$line->fk_remise_except = $objp->fk_remise_except;
-				$line->fk_product       = $objp->fk_product;
-				$line->date_start       = $this->db->jdate($objp->date_start);
-				$line->date_end         = $this->db->jdate($objp->date_end);
-				$line->info_bits        = $objp->info_bits;
-				$line->total_ht         = $objp->total_ht;
-				$line->total_tva        = $objp->total_tva;
+				$line->fk_product	   = $objp->fk_product;
+				$line->date_start	   = $this->db->jdate($objp->date_start);
+				$line->date_end		 = $this->db->jdate($objp->date_end);
+				$line->info_bits		= $objp->info_bits;
+				$line->total_ht		 = $objp->total_ht;
+				$line->total_tva		= $objp->total_tva;
 				$line->total_localtax1  = $objp->total_localtax1;
 				$line->total_localtax2  = $objp->total_localtax2;
-				$line->total_ttc        = $objp->total_ttc;
+				$line->total_ttc		= $objp->total_ttc;
 
 				$line->code_ventilation = $objp->fk_code_ventilation;
 				$line->fk_fournprice = $objp->fk_fournprice;
@@ -2625,7 +2625,7 @@ class Facture extends CommonInvoice
 	{
 		global $conf;
 
-		// Load situation invoices before and after this one 
+		// Load situation invoices before and after this one
 		$this->fetchPreviousNextSituationInvoice();
 
 		// Get last invoice in the serie
@@ -2667,7 +2667,7 @@ class Facture extends CommonInvoice
 
 		return round($avancementGlobal, 2);
 	}
-	
+
 	/** 
 	 * Compute the marginal progress of the invoice.
 	 * Return the 2 digit rounded progress, as percent.
@@ -2694,11 +2694,11 @@ class Facture extends CommonInvoice
 
 
 	/**
-	 *      Update database
+	 *	  Update database
 	 *
-	 *      @param      User	$user        	User that modify
-	 *      @param      int		$notrigger	    0=launch triggers after, 1=disable triggers
-	 *      @return     int      			   	Return integer <0 if KO, >0 if OK
+	 *	  @param	  User	$user			User that modify
+	 *	  @param	  int		$notrigger		0=launch triggers after, 1=disable triggers
+	 *	  @return	 int	  			   	Return integer <0 if KO, >0 if OK
 	 */
 	public function update(User $user, $notrigger = 0)
 	{
@@ -2843,10 +2843,10 @@ class Facture extends CommonInvoice
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
-	 *    Add a discount line into an invoice (as an invoice line) using an existing absolute discount (Consume the discount)
+	 *	Add a discount line into an invoice (as an invoice line) using an existing absolute discount (Consume the discount)
 	 *
-	 *    @param     int	$idremise	Id of absolute discount
-	 *    @return    int          		>0 if OK, <0 if KO
+	 *	@param	 int	$idremise	Id of absolute discount
+	 *	@return	int		  		>0 if OK, <0 if KO
 	 */
 	public function insert_discount($idremise)
 	{
@@ -2942,8 +2942,8 @@ class Facture extends CommonInvoice
 	/**
 	 *	Set customer ref
 	 *
-	 *	@param     	string	$ref_client		Customer ref
-	 *  @param     	int		$notrigger		1=Does not execute triggers, 0= execute triggers
+	 *	@param	 	string	$ref_client		Customer ref
+	 *  @param	 	int		$notrigger		1=Does not execute triggers, 0= execute triggers
 	 *	@return		int						Return integer <0 if KO, >0 if OK
 	 */
 	public function set_ref_client($ref_client, $notrigger = 0)
@@ -3001,7 +3001,7 @@ class Facture extends CommonInvoice
 	/**
 	 *	Delete invoice
 	 *
-	 *	@param     	User	$user      	    User making the deletion.
+	 *	@param	 	User	$user	  		User making the deletion.
 	 *	@param		int		$notrigger		1=Does not execute triggers, 0= execute triggers
 	 *	@param		int		$idwarehouse	Id warehouse to use for stock change.
 	 *	@return		int						Return integer <0 if KO, 0=Refused, >0 if OK
@@ -3195,10 +3195,10 @@ class Facture extends CommonInvoice
 	 *
 	 *	@deprecated
 	 *  @see setPaid()
-	 *  @param	User	$user      	Object user that modify
+	 *  @param	User	$user	  	Object user that modify
 	 *	@param  string	$close_code	Code renseigne si on classe a payee completement alors que paiement incomplet (cas escompte par exemple)
 	 *	@param  string	$close_note	Commentaire renseigne si on classe a payee alors que paiement incomplet (cas escompte par exemple)
-	 *  @return int         		Return integer <0 if KO, >0 if OK
+	 *  @return int		 		Return integer <0 if KO, >0 if OK
 	 */
 	public function set_paid($user, $close_code = '', $close_note = '')
 	{
@@ -3212,10 +3212,10 @@ class Facture extends CommonInvoice
 	 *  - paid completely (if close_code is not filled) => this->fk_statut=2, this->paye=1
 	 *  - or partially (if close_code filled) + appel trigger BILL_PAYED => this->fk_statut=2, this->paye stay 0
 	 *
-	 *  @param	User	$user      	Object user that modify
+	 *  @param	User	$user	  	Object user that modify
 	 *	@param  string	$close_code	Code renseigne si on classe a payee completement alors que paiement incomplet (cas escompte par exemple)
 	 *	@param  string	$close_note	Commentaire renseigne si on classe a payee alors que paiement incomplet (cas escompte par exemple)
-	 *  @return int         		Return integer <0 if KO, >0 if OK
+	 *  @return int		 		Return integer <0 if KO, >0 if OK
 	 */
 	public function setPaid($user, $close_code = '', $close_note = '')
 	{
@@ -3277,8 +3277,8 @@ class Facture extends CommonInvoice
 	 *
 	 *	@deprecated
 	 *  @see setUnpaid()
-	 *  @param	User	$user       Object user that change status
-	 *  @return int         		Return integer <0 if KO, >0 if OK
+	 *  @param	User	$user	   Object user that change status
+	 *  @return int		 		Return integer <0 if KO, >0 if OK
 	 */
 	public function set_unpaid($user)
 	{
@@ -3292,8 +3292,8 @@ class Facture extends CommonInvoice
 	 *	Fonction utilisee quand un paiement prelevement est refuse,
 	 * 	ou quand une facture annulee et reouverte.
 	 *
-	 *  @param	User	$user       Object user that change status
-	 *  @return int         		Return integer <0 if KO, >0 if OK
+	 *  @param	User	$user	   Object user that change status
+	 *  @return int		 		Return integer <0 if KO, >0 if OK
 	 */
 	public function setUnpaid($user)
 	{
@@ -3340,10 +3340,10 @@ class Facture extends CommonInvoice
 	 *
 	 *	@deprecated
 	 *  @see setCanceled()
-	 *	@param	User	$user        	Object user making change
+	 *	@param	User	$user			Object user making change
 	 *	@param	string	$close_code		Code of closing invoice (CLOSECODE_REPLACED, CLOSECODE_...)
 	 *	@param	string	$close_note		Comment
-	 *	@return int         			Return integer <0 if KO, >0 if OK
+	 *	@return int		 			Return integer <0 if KO, >0 if OK
 	 */
 	public function set_canceled($user, $close_code = '', $close_note = '')
 	{
@@ -3357,10 +3357,10 @@ class Facture extends CommonInvoice
 	 *	Warning, if option to decrease stock on invoice was set, this function does not change stock (it might be a cancel because
 	 *  of no payment even if merchandises were sent).
 	 *
-	 *	@param	User	$user        	Object user making change
+	 *	@param	User	$user			Object user making change
 	 *	@param	string	$close_code		Code of closing invoice (CLOSECODE_REPLACED, CLOSECODE_...)
 	 *	@param	string	$close_note		Comment
-	 *	@return int         			Return integer <0 if KO, >0 if OK
+	 *	@return int		 			Return integer <0 if KO, >0 if OK
 	 */
 	public function setCanceled($user, $close_code = '', $close_note = '')
 	{
@@ -3417,7 +3417,7 @@ class Facture extends CommonInvoice
 	 * Tag invoice as validated + call trigger BILL_VALIDATE
 	 * Object must have lines loaded with fetch_lines
 	 *
-	 * @param	User	$user           Object user that validate
+	 * @param	User	$user		   Object user that validate
 	 * @param   string	$force_number	Reference to force on invoice
 	 * @param	int		$idwarehouse	Id of warehouse to use for stock decrease if option to decrease on stock is on (0=no decrease)
 	 * @param	int		$notrigger		1=Does not execute triggers, 0= execute triggers
@@ -4007,23 +4007,23 @@ class Facture extends CommonInvoice
 	 *  par l'appelant par la methode get_default_tva(societe_vendeuse,societe_acheteuse,produit)
 	 *  et le desc doit deja avoir la bonne valeur (a l'appelant de gerer le multilangue)
 	 *
-	 *  @param    	string		$desc            	Description of line
-	 *  @param    	double		$pu_ht              Unit price without tax (> 0 even for credit note)
-	 *  @param    	double		$qty             	Quantity
-	 *  @param    	double		$txtva           	Force Vat rate, -1 for auto (Can contain the vat_src_code too with syntax '9.9 (CODE)')
+	 *  @param		string		$desc				Description of line
+	 *  @param		double		$pu_ht			  Unit price without tax (> 0 even for credit note)
+	 *  @param		double		$qty			 	Quantity
+	 *  @param		double		$txtva		   	Force Vat rate, -1 for auto (Can contain the vat_src_code too with syntax '9.9 (CODE)')
 	 *  @param		double		$txlocaltax1		Local tax 1 rate (deprecated, use instead txtva with code inside)
 	 *  @param		double		$txlocaltax2		Local tax 2 rate (deprecated, use instead txtva with code inside)
-	 *  @param    	int			$fk_product      	Id of predefined product/service
-	 *  @param    	double		$remise_percent  	Percent of discount on line
-	 *  @param    	int|string	$date_start      	Date start of service
-	 *  @param    	int|string	$date_end        	Date end of service
-	 *  @param    	int			$ventil          	Code of dispatching into accountancy
-	 *  @param    	int			$info_bits			Bits of type of lines
-	 *  @param    	int			$fk_remise_except	Id discount used
+	 *  @param		int			$fk_product	  	Id of predefined product/service
+	 *  @param		double		$remise_percent  	Percent of discount on line
+	 *  @param		int|string	$date_start	  	Date start of service
+	 *  @param		int|string	$date_end			Date end of service
+	 *  @param		int			$ventil		  	Code of dispatching into accountancy
+	 *  @param		int			$info_bits			Bits of type of lines
+	 *  @param		int			$fk_remise_except	Id discount used
 	 *  @param		string		$price_base_type	'HT' or 'TTC'
-	 *  @param    	double		$pu_ttc             Unit price with tax (> 0 even for credit note)
+	 *  @param		double		$pu_ttc			 Unit price with tax (> 0 even for credit note)
 	 *  @param		int			$type				Type of line (0=product, 1=service). Not used if fk_product is defined, the type of product is used.
-	 *  @param      int			$rang               Position of line (-1 means last value + 1)
+	 *  @param	  int			$rang			   Position of line (-1 means last value + 1)
 	 *  @param		int			$special_code		Special code (also used by externals modules!)
 	 *  @param		string		$origin				Depend on global conf MAIN_CREATEFROM_KEEP_LINE_ORIGIN_INFORMATION can be 'orderdet', 'propaldet'..., else 'order','propal,'....
 	 *  @param		int			$origin_id			Depend on global conf MAIN_CREATEFROM_KEEP_LINE_ORIGIN_INFORMATION can be Id of origin object (aka line id), else object id
@@ -4032,13 +4032,13 @@ class Facture extends CommonInvoice
 	 *  @param		int			$pa_ht				Buying price of line (to calculate margin) or ''
 	 *  @param		string		$label				Label of the line (deprecated, do not use)
 	 *  @param		array		$array_options		extrafields array
-	 *  @param      int         $situation_percent  Situation advance percentage
-	 *  @param      int         $fk_prev_id         Previous situation line id reference
+	 *  @param	  int		 $situation_percent  Situation advance percentage
+	 *  @param	  int		 $fk_prev_id		 Previous situation line id reference
 	 *  @param 		string		$fk_unit 			Code of the unit to use. Null to use the default one
 	 *  @param		double		$pu_ht_devise		Unit price in foreign currency
-	 *  @param		string		$ref_ext		    External reference of the line
+	 *  @param		string		$ref_ext			External reference of the line
 	 *  @param		int			$noupdateafterinsertline	No update after insert of line
-	 *  @return    	int             				Return integer <0 if KO, Id of line if OK
+	 *  @return		int			 				Return integer <0 if KO, Id of line if OK
 	 */
 	public function addline(
 		$desc,
@@ -4308,18 +4308,18 @@ class Facture extends CommonInvoice
 	/**
 	 *  Update a detail line
 	 *
-	 *  @param     	int			$rowid           	Id of line to update
-	 *  @param     	string		$desc            	Description of line
-	 *  @param     	double		$pu              	Prix unitaire (HT ou TTC selon price_base_type) (> 0 even for credit note lines)
-	 *  @param     	double		$qty             	Quantity
-	 *  @param     	double		$remise_percent  	Percentage discount of the line
-	 *  @param     	int		    $date_start      	Date de debut de validite du service
-	 *  @param     	int		    $date_end        	Date de fin de validite du service
-	 *  @param     	double|string	$txtva          	VAT Rate (Can be '8.5', '8.5 (ABC)')
+	 *  @param	 	int			$rowid		   	Id of line to update
+	 *  @param	 	string		$desc				Description of line
+	 *  @param	 	double		$pu			  	Prix unitaire (HT ou TTC selon price_base_type) (> 0 even for credit note lines)
+	 *  @param	 	double		$qty			 	Quantity
+	 *  @param	 	double		$remise_percent  	Percentage discount of the line
+	 *  @param	 	int			$date_start	  	Date de debut de validite du service
+	 *  @param	 	int			$date_end			Date de fin de validite du service
+	 *  @param	 	double|string	$txtva		  	VAT Rate (Can be '8.5', '8.5 (ABC)')
 	 * 	@param		double		$txlocaltax1		Local tax 1 rate
 	 *  @param		double		$txlocaltax2		Local tax 2 rate
-	 * 	@param     	string		$price_base_type 	HT or TTC
-	 * 	@param     	int			$info_bits 		    Miscellaneous informations
+	 * 	@param	 	string		$price_base_type 	HT or TTC
+	 * 	@param	 	int			$info_bits 			Miscellaneous informations
 	 * 	@param		int			$type				Type of line (0=product, 1=service)
 	 * 	@param		int			$fk_parent_line		Id of parent line (0 in most cases, used by modules adding sublevels into lines).
 	 * 	@param		int			$skip_update_total	Keep fields total_xxx to 0 (used for special lines by some modules)
@@ -4328,13 +4328,13 @@ class Facture extends CommonInvoice
 	 * 	@param		string		$label				Label of the line (deprecated, do not use)
 	 * 	@param		int			$special_code		Special code (also used by externals modules!)
 	 *  @param		array		$array_options		extrafields array
-	 * 	@param      int         $situation_percent  Situation advance percentage
+	 * 	@param	  int		 $situation_percent  Situation advance percentage
 	 * 	@param 		string		$fk_unit 			Code of the unit to use. Null to use the default one
 	 * 	@param		double		$pu_ht_devise		Unit price in currency
 	 * 	@param		int			$notrigger			disable line update trigger
-	 *  @param		string		$ref_ext		    External reference of the line
-	 *  @param		integer		$rang		    	rank of line
-	 *  @return    	int             				Return integer < 0 if KO, > 0 if OK
+	 *  @param		string		$ref_ext			External reference of the line
+	 *  @param		integer		$rang				rank of line
+	 *  @return		int			 				Return integer < 0 if KO, > 0 if OK
 	 */
 	public function updateline($rowid, $desc, $pu, $qty, $remise_percent, $date_start, $date_end, $txtva, $txlocaltax1 = 0, $txlocaltax2 = 0, $price_base_type = 'HT', $info_bits = 0, $type = self::TYPE_STANDARD, $fk_parent_line = 0, $skip_update_total = 0, $fk_fournprice = null, $pa_ht = 0, $label = '', $special_code = 0, $array_options = array(), $situation_percent = 100, $fk_unit = null, $pu_ht_devise = 0, $notrigger = 0, $ref_ext = '', $rang = 0)
 	{
@@ -4573,9 +4573,9 @@ class Facture extends CommonInvoice
 	/**
 	 * Update invoice line with percentage
 	 *
-	 * @param  FactureLigne $line       	Invoice line
-	 * @param  int          $percent    	Percentage
-	 * @param  boolean      $update_price   Update object price
+	 * @param  FactureLigne $line	   	Invoice line
+	 * @param  int		  $percent		Percentage
+	 * @param  boolean	  $update_price   Update object price
 	 * @return void
 	 */
 	public function update_percent($line, $percent, $update_price = true)
@@ -4676,9 +4676,9 @@ class Facture extends CommonInvoice
 	 *
 	 *  @deprecated
 	 *  @see setDiscount()
-	 *	@param     	User	$user		User that set discount
-	 *	@param     	double	$remise		Discount
-	 *  @param     	int		$notrigger	1=Does not execute triggers, 0= execute triggers
+	 *	@param	 	User	$user		User that set discount
+	 *	@param	 	double	$remise		Discount
+	 *  @param	 	int		$notrigger	1=Does not execute triggers, 0= execute triggers
 	 *	@return		int 				Return integer <0 if KO, >0 if OK
 	 */
 	public function set_remise($user, $remise, $notrigger = 0)
@@ -4691,9 +4691,9 @@ class Facture extends CommonInvoice
 	/**
 	 *	Set percent discount
 	 *
-	 *	@param     	User	$user		User that set discount
-	 *	@param     	double	$remise		Discount
-	 *  @param     	int		$notrigger	1=Does not execute triggers, 0= execute triggers
+	 *	@param	 	User	$user		User that set discount
+	 *	@param	 	double	$remise		Discount
+	 *  @param	 	int		$notrigger	1=Does not execute triggers, 0= execute triggers
 	 *	@return		int 				Return integer <0 if KO, >0 if OK
 	 *	@deprecated remise_percent is a deprecated field for object parent
 	 */
@@ -4756,9 +4756,9 @@ class Facture extends CommonInvoice
 	/**
 	 *	Set absolute discount
 	 *
-	 *	@param     	User	$user 		User that set discount
-	 *	@param     	double	$remise		Discount
-	 *  @param     	int		$notrigger	1=Does not execute triggers, 0= execute triggers
+	 *	@param	 	User	$user 		User that set discount
+	 *	@param	 	double	$remise		Discount
+	 *  @param	 	int		$notrigger	1=Does not execute triggers, 0= execute triggers
 	 *	@return		int 				Return integer <0 if KO, >0 if OK
 	 */
 	/*
@@ -4821,12 +4821,12 @@ class Facture extends CommonInvoice
 	*/
 
 	/**
-	 *      Return next reference of customer invoice not already used (or last reference)
-	 *      according to numbering module defined into constant FACTURE_ADDON
+	 *	  Return next reference of customer invoice not already used (or last reference)
+	 *	  according to numbering module defined into constant FACTURE_ADDON
 	 *
-	 *      @param	   Societe		$soc		object company
-	 *      @param     string		$mode		'next' for next value or 'last' for last value
-	 *      @return    string					free ref or last ref
+	 *	  @param	   Societe		$soc		object company
+	 *	  @param	 string		$mode		'next' for next value or 'last' for last value
+	 *	  @return	string					free ref or last ref
 	 */
 	public function getNextNumRef($soc, $mode = 'next')
 	{
@@ -4951,10 +4951,10 @@ class Facture extends CommonInvoice
 				$this->user_validation_id = $obj->fk_user_valid;
 				$this->user_closing_id = $obj->fk_user_closing;
 
-				$this->date_creation     = $this->db->jdate($obj->datec);
+				$this->date_creation	 = $this->db->jdate($obj->datec);
 				$this->date_modification = $this->db->jdate($obj->datem);
 				$this->date_validation   = $this->db->jdate($obj->datev);
-				$this->date_closing      = $this->db->jdate($obj->dateclosing);
+				$this->date_closing	  = $this->db->jdate($obj->dateclosing);
 			}
 			$this->db->free($result);
 		} else {
@@ -4968,14 +4968,14 @@ class Facture extends CommonInvoice
 	 *  Return list of invoices (eventually filtered on a user) into an array
 	 *
 	 *  @param		int		$shortlist		0=Return array[id]=ref, 1=Return array[](id=>id,ref=>ref,name=>name)
-	 *  @param      int		$draft      	0=not draft, 1=draft
-	 *  @param      User	$excluser      	Objet user to exclude
-	 *  @param    	int		$socid			Id third pary
-	 *  @param    	int		$limit			For pagination
-	 *  @param    	int		$offset			For pagination
-	 *  @param    	string	$sortfield		Sort criteria
-	 *  @param    	string	$sortorder		Sort order
-	 *  @return     array|int             	-1 if KO, array with result if OK
+	 *  @param	  int		$draft	  	0=not draft, 1=draft
+	 *  @param	  User	$excluser	  	Objet user to exclude
+	 *  @param		int		$socid			Id third pary
+	 *  @param		int		$limit			For pagination
+	 *  @param		int		$offset			For pagination
+	 *  @param		string	$sortfield		Sort criteria
+	 *  @param		string	$sortorder		Sort order
+	 *  @return	 array|int			 	-1 if KO, array with result if OK
 	 */
 	public function liste_array($shortlist = 0, $draft = 0, $excluser = null, $socid = 0, $limit = 0, $offset = 0, $sortfield = 'f.datef,f.rowid', $sortorder = 'DESC')
 	{
@@ -5045,7 +5045,7 @@ class Facture extends CommonInvoice
 	 *	(Status validated or abandonned for a reason 'other') + not payed + no payment at all + not already replaced
 	 *
 	 *	@param		int			$socid		Id thirdparty
-	 *	@return    	array|int				Array of invoices ('id'=>id, 'ref'=>ref, 'status'=>status, 'paymentornot'=>0/1)
+	 *	@return		array|int				Array of invoices ('id'=>id, 'ref'=>ref, 'status'=>status, 'paymentornot'=>0/1)
 	 */
 	public function list_replacable_invoices($socid = 0)
 	{
@@ -5099,7 +5099,7 @@ class Facture extends CommonInvoice
 	 *	(validated + payment on process) or classified (payed completely or payed partiely) + not already replaced + not already a credit note
 	 *
 	 *	@param		int			$socid		Id thirdparty
-	 *	@return    	array|int				Array of invoices ($id => array('ref'=>,'paymentornot'=>,'status'=>,'paye'=>)
+	 *	@return		array|int				Array of invoices ($id => array('ref'=>,'paymentornot'=>,'status'=>,'paye'=>)
 	 */
 	public function list_qualified_avoir_invoices($socid = 0)
 	{
@@ -5173,7 +5173,7 @@ class Facture extends CommonInvoice
 	/**
 	 *	Load indicators for dashboard (this->nbtodo and this->nbtodolate)
 	 *
-	 *	@param  User					$user    	Object user
+	 *	@param  User					$user		Object user
 	 *	@return WorkboardResponse|int 				Return integer <0 if KO, WorkboardResponse if OK
 	 */
 	public function load_board($user)
@@ -5240,7 +5240,7 @@ class Facture extends CommonInvoice
 	/**
 	 *	Retourne id des contacts clients de facturation
 	 *
-	 *	@return     array       Liste des id contacts facturation
+	 *	@return	 array	   Liste des id contacts facturation
 	 */
 	public function getIdBillingContact()
 	{
@@ -5250,7 +5250,7 @@ class Facture extends CommonInvoice
 	/**
 	 *	Retourne id des contacts clients de livraison
 	 *
-	 *	@return     array       Liste des id contacts livraison
+	 *	@return	 array	   Liste des id contacts livraison
 	 */
 	public function getIdShippingContact()
 	{
@@ -5336,7 +5336,7 @@ class Facture extends CommonInvoice
 				$line->localtax1_tx = 0;
 				$line->localtax2_tx = 0;
 				$line->remise_percent = 0;
-				if ($xnbp == 1) {        // Qty is negative (product line)
+				if ($xnbp == 1) {		// Qty is negative (product line)
 					$prodid = mt_rand(1, $num_prods);
 					$line->fk_product = $prodids[$prodid];
 					$line->qty = -1;
@@ -5346,7 +5346,7 @@ class Facture extends CommonInvoice
 					$line->multicurrency_total_ht = -200;
 					$line->multicurrency_total_ttc = -239.2;
 					$line->multicurrency_total_tva = -39.2;
-				} elseif ($xnbp == 2) {    // UP is negative (free line)
+				} elseif ($xnbp == 2) {	// UP is negative (free line)
 					$line->subprice = -100;
 					$line->total_ht = -100;
 					$line->total_ttc = -119.6;
@@ -5355,7 +5355,7 @@ class Facture extends CommonInvoice
 					$line->multicurrency_total_ht = -200;
 					$line->multicurrency_total_ttc = -239.2;
 					$line->multicurrency_total_tva = -39.2;
-				} elseif ($xnbp == 3) {    // Discount is 50% (product line)
+				} elseif ($xnbp == 3) {	// Discount is 50% (product line)
 					$prodid = mt_rand(1, $num_prods);
 					$line->fk_product = $prodids[$prodid];
 					$line->total_ht = 50;
@@ -5380,13 +5380,13 @@ class Facture extends CommonInvoice
 				$this->lines[$xnbp] = $line;
 
 
-				$this->total_ht       += $line->total_ht;
-				$this->total_tva      += $line->total_tva;
-				$this->total_ttc      += $line->total_ttc;
+				$this->total_ht	   += $line->total_ht;
+				$this->total_tva	  += $line->total_tva;
+				$this->total_ttc	  += $line->total_ttc;
 
-				$this->multicurrency_total_ht       += $line->multicurrency_total_ht;
-				$this->multicurrency_total_tva      += $line->multicurrency_total_tva;
-				$this->multicurrency_total_ttc      += $line->multicurrency_total_ttc;
+				$this->multicurrency_total_ht	   += $line->multicurrency_total_ht;
+				$this->multicurrency_total_tva	  += $line->multicurrency_total_tva;
+				$this->multicurrency_total_ttc	  += $line->multicurrency_total_ttc;
 
 				$xnbp++;
 			}
@@ -5417,9 +5417,9 @@ class Facture extends CommonInvoice
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
-	 *      Load indicators for dashboard (this->nbtodo and this->nbtodolate)
+	 *	  Load indicators for dashboard (this->nbtodo and this->nbtodolate)
 	 *
-	 *      @return         int     Return integer <0 if KO, >0 if OK
+	 *	  @return		 int	 Return integer <0 if KO, >0 if OK
 	 */
 	public function load_state_board()
 	{
@@ -5469,11 +5469,11 @@ class Facture extends CommonInvoice
 	 *
 	 *	@param	string		$modele			Generator to use. Caller must set it to obj->model_pdf or GETPOST('model','alpha') for example.
 	 *	@param	Translate	$outputlangs	Object lang to use for translation
-	 *  @param  int			$hidedetails    Hide details of lines
-	 *  @param  int			$hidedesc       Hide description
-	 *  @param  int			$hideref        Hide ref
-	 *  @param  null|array  $moreparams     Array to provide more information
-	 *	@return int        					Return integer <0 if KO, >0 if OK
+	 *  @param  int			$hidedetails	Hide details of lines
+	 *  @param  int			$hidedesc	   Hide description
+	 *  @param  int			$hideref		Hide ref
+	 *  @param  null|array  $moreparams	 Array to provide more information
+	 *	@return int							Return integer <0 if KO, >0 if OK
 	 */
 	public function generateDocument($modele, $outputlangs, $hidedetails = 0, $hidedesc = 0, $hideref = 0, $moreparams = null)
 	{
@@ -5574,8 +5574,8 @@ class Facture extends CommonInvoice
 	/**
 	 * Sets the invoice as a final situation
 	 *
-	 *  @param  	User	$user    	Object user
-	 *  @param     	int		$notrigger	1=Does not execute triggers, 0= execute triggers
+	 *  @param  	User	$user		Object user
+	 *  @param	 	int		$notrigger	1=Does not execute triggers, 0= execute triggers
 	 *	@return		int 				Return integer <0 if KO, >0 if OK
 	 */
 	public function setFinal(User $user, $notrigger = 0)
@@ -5888,7 +5888,7 @@ class Facture extends CommonInvoice
 	 *  @param	int|string	$template			Name (or id) of email template (Must be a template of type 'facture_send')
 	 *  @param	string		$datetouse			'duedate' (default) or 'invoicedate'
 	 *  @param	string		$forcerecipient		Force email of recipient (for example to send the email to an accountant supervisor instead of the customer)
-	 *  @return int         					0 if OK, <>0 if KO (this function is used also by cron so only 0 is OK)
+	 *  @return int		 					0 if OK, <>0 if KO (this function is used also by cron so only 0 is OK)
 	 */
 	public function sendEmailsRemindersOnInvoiceDueDate($nbdays = 0, $paymentmode = 'all', $template = '', $datetouse = 'duedate', $forcerecipient = '')
 	{
@@ -6234,7 +6234,7 @@ class Facture extends CommonInvoice
 	/**
 	 *	Return clicable link of object (with eventually picto)
 	 *
-	 *	@param      string	    $option                 Where point the link (0=> main card, 1,2 => shipment, 'nolink'=>No link)
+	 *	@param	  string		$option				 Where point the link (0=> main card, 1,2 => shipment, 'nolink'=>No link)
 	 *  @param		array		$arraydata				Array of data
 	 *  @return		string								HTML Code for Kanban thumb.
 	 */
@@ -6279,7 +6279,7 @@ class Facture extends CommonInvoice
 	 *	Set prorata_discount from rate 
 	 * 	To change with PHP8.4
 	 *
-	 *	@param      float	    $rate                 	Prorata rate, between 0 and 100
+	 *	@param	  float		$rate				 	Prorata rate, between 0 and 100
 	 *  @return		string								1 if OK, -1 if NOK.
 	 */
 	public function setProrataFromRate($rate = 0)
@@ -6389,9 +6389,9 @@ class FactureLigne extends CommonInvoiceLine
 	public $fk_prev_id;
 
 	/**
-	 *      Constructor
+	 *	  Constructor
 	 *
-	 *      @param     DoliDB	$db      handler d'acces base de donnee
+	 *	  @param	 DoliDB	$db	  handler d'acces base de donnee
 	 */
 	public function __construct($db)
 	{
@@ -6401,7 +6401,7 @@ class FactureLigne extends CommonInvoiceLine
 	/**
 	 *	Load invoice line from database
 	 *
-	 *	@param	int		$rowid      id of invoice line to get
+	 *	@param	int		$rowid	  id of invoice line to get
 	 *	@return	int					Return integer <0 if KO, >0 if OK
 	 */
 	public function fetch($rowid)
@@ -6476,8 +6476,8 @@ class FactureLigne extends CommonInvoiceLine
 			$this->fk_user_modif		= $objp->fk_user_modif;
 			$this->fk_user_author = $objp->fk_user_author;
 
-			$this->situation_percent    = $objp->situation_percent;
-			$this->fk_prev_id           = $objp->fk_prev_id;
+			$this->situation_percent	= $objp->situation_percent;
+			$this->fk_prev_id		   = $objp->fk_prev_id;
 
 			$this->multicurrency_subprice = $objp->multicurrency_subprice;
 			$this->multicurrency_total_ht = $objp->multicurrency_total_ht;
@@ -6498,9 +6498,9 @@ class FactureLigne extends CommonInvoiceLine
 	/**
 	 *	Insert line into database
 	 *
-	 *	@param      int		$notrigger		                 1 no triggers
-	 *  @param      int     $noerrorifdiscountalreadylinked  1=Do not make error if lines is linked to a discount and discount already linked to another
-	 *	@return		int						                 Return integer <0 if KO, >0 if OK
+	 *	@param	  int		$notrigger						 1 no triggers
+	 *  @param	  int	 $noerrorifdiscountalreadylinked  1=Do not make error if lines is linked to a discount and discount already linked to another
+	 *	@return		int										 Return integer <0 if KO, >0 if OK
 	 */
 	public function insert($notrigger = 0, $noerrorifdiscountalreadylinked = 0)
 	{
@@ -6906,9 +6906,9 @@ class FactureLigne extends CommonInvoiceLine
 	/**
 	 * Delete line in database
 	 *
-	 * @param 	User 	$tmpuser    User that deletes
+	 * @param 	User 	$tmpuser	User that deletes
 	 * @param 	bool 	$notrigger  false=launch triggers after, true=disable triggers
-	 * @return 	int		           	Return integer <0 if KO, >0 if OK
+	 * @return 	int				   	Return integer <0 if KO, >0 if OK
 	 */
 	public function delete($tmpuser = null, $notrigger = false)
 	{
@@ -7018,9 +7018,9 @@ class FactureLigne extends CommonInvoiceLine
 	 * Returns situation_percent of the previous line.
 	 * Warning: If invoice is a replacement invoice, this->fk_prev_id is id of the replaced line.
 	 *
-	 * @param  int     $invoiceid      			Invoice id
-	 * @param  bool    $include_credit_note		Include credit note or not
-	 * @return int                     			>= 0
+	 * @param  int	 $invoiceid	  			Invoice id
+	 * @param  bool	$include_credit_note		Include credit note or not
+	 * @return int					 			>= 0
 	 */
 	public function get_prev_progress($invoiceid, $include_credit_note = true)
 	{

--- a/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
@@ -3,10 +3,10 @@
  * Copyright (C) 2005-2012	Regis Houssin		<regis.houssin@capnetworks.com>
  * Copyright (C) 2008		Raphael Bertrand	<raphael.bertrand@resultic.fr>
  * Copyright (C) 2010-2014	Juanjo Menent		<jmenent@2byte.es>
- * Copyright (C) 2012      	Christophe Battarel <christophe.battarel@altairis.fr>
- * Copyright (C) 2012       Cédric Salvador     <csalvador@gpcsolutions.fr>
+ * Copyright (C) 2012	  	Christophe Battarel <christophe.battarel@altairis.fr>
+ * Copyright (C) 2012	   Cédric Salvador	 <csalvador@gpcsolutions.fr>
  * Copyright (C) 2012-2014  Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
- * Copyright (C) 2015       Marcos García       <marcosgdf@gmail.com>
+ * Copyright (C) 2015	   Marcos García	   <marcosgdf@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,9 +24,9 @@
  */
 
 /**
- *	\file       htdocs/core/modules/facture/doc/pdf_crabe.modules.php
- *	\ingroup    facture
- *	\brief      File of class to generate customers invoices from crabe model
+ *	\file	   htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+ *	\ingroup	facture
+ *	\brief	  File of class to generate customers invoices from crabe model
  */
 
 require_once DOL_DOCUMENT_ROOT.'/core/modules/facture/modules_facture.php';
@@ -43,17 +43,17 @@ if (isModEnabled('subtotal')) dol_include_once('/subtotal/class/subtotal.class.p
  */
 class pdf_couffignal_situation extends ModelePDFFactures
 {
-    var $db;
-    var $name;
-    var $description;
-    var $type;
+	var $db;
+	var $name;
+	var $description;
+	var $type;
 
-    var $phpmin = array(4,3,0); // Minimum version of PHP required by module
-    var $version = 'dolibarr';
+	var $phpmin = array(4,3,0); // Minimum version of PHP required by module
+	var $version = 'dolibarr';
 
-    var $page_width;
-    var $page_height;
-    var $format;
+	var $page_width;
+	var $page_height;
+	var $format;
 	var $margin_left;
 	var	$margin_right;
 	var	$marge_haute;
@@ -76,7 +76,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	/**
 	 *	Constructor
 	 *
-	 *  @param		DoliDB		$db      Database handler
+	 *  @param		DoliDB		$db	  Database handler
 	 */
 	function __construct($db)
 	{
@@ -103,14 +103,14 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$this->heightforfreetext = getDolGlobalInt('MAIN_PDF_FREETEXT_HEIGHT', 5); // Height reserved to output the free text on last page
 		$this->heightforinfotot = $this->margin_bottom + 20;	// Height reserved to output the footer (value include bottom margin)
 
-		$this->option_logo = 1;                    // Affiche logo
-		$this->option_tva = 1;                     // Manage option tva FACTURE_TVAOPTION
-		$this->option_modereg = 1;                 // Affiche mode reglement
-		$this->option_condreg = 1;                 // Affiche conditions reglement
-		$this->option_codeproduitservice = 1;      // Affiche code produit-service
-		$this->option_multilang = 1;               // Dispo en plusieurs langues
-		$this->option_escompte = 1;                // Affiche si il y a eu escompte
-		$this->option_credit_note = 1;             // Support credit notes
+		$this->option_logo = 1;					// Affiche logo
+		$this->option_tva = 1;					 // Manage option tva FACTURE_TVAOPTION
+		$this->option_modereg = 1;				 // Affiche mode reglement
+		$this->option_condreg = 1;				 // Affiche conditions reglement
+		$this->option_codeproduitservice = 1;	  // Affiche code produit-service
+		$this->option_multilang = 1;			   // Dispo en plusieurs langues
+		$this->option_escompte = 1;				// Affiche si il y a eu escompte
+		$this->option_credit_note = 1;			 // Support credit notes
 		$this->option_freetext = 1;				   // Support add of a personalised text
 		$this->option_draft_watermark = 1;		   // Support add of a watermark on drafts
 
@@ -120,7 +120,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 		// Define various properties
 		$this->issuer=$mysoc;
-		if (empty($this->issuer->country_code)) $this->issuer->country_code = substr($langs->defaultlang,-2);    // By default, if was not defined
+		if (empty($this->issuer->country_code)) $this->issuer->country_code = substr($langs->defaultlang,-2);	// By default, if was not defined
 		$this->franchise =! $mysoc->tva_assuj;
 		$this->tva = array();
 		$this->localtax1 = array();
@@ -251,10 +251,10 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	}
 
 	/**
-     *  Function to compute size of the columns
-     * 	Populate attribute columns in $this with 2nd dimension width & start
-     *
-     *  @return     int         	    			1=OK, 0=KO
+	 *  Function to compute size of the columns
+	 * 	Populate attribute columns in $this with 2nd dimension width & start
+	 *
+	 *  @return	 int		 					1=OK, 0=KO
 	 */
 	function compute_columns_size()
 	{
@@ -271,7 +271,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			unset($properties["WidthPt"]);
 			array_push($this->columns, $properties);
 		}
-		for ($i=0; $i < count($this->columns); $i++) { 
+		for ($i=0; $i < count($this->columns); $i++) {
 			if ($i == 0) {
 				$this->columns[$i]['Start'] = $this->margin_left;
 			} else {
@@ -284,9 +284,9 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 
 	/**
-     *  Function to print a description line
-     *
-     *  @param  TCPDF			$pdf               	PDF object
+	 *  Function to print a description line
+	 *
+	 *  @param  TCPDF			$pdf			   	PDF object
 	 *	@param	Object			$object				Current Invoice Object
 	 *	@param	int				$i					Current line number
 	 *  @param  Translate		$outputlangs		Object lang for output
@@ -294,10 +294,10 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	 *  @param  int				$h					Height
 	 *  @param  int				$posx				Pos x
 	 *  @param  int				$posy				Pos y
-	 *  @param  int				$this->hideref       		Hide reference
-	 *  @param  int				$this->hidedesc           Hide description
+	 *  @param  int				$this->hideref	   		Hide reference
+	 *  @param  int				$this->hidedesc		   Hide description
 	 * 	@param	int				$issupplierline		Is it a line for a supplier object ?
-     *  @return int         	    			1=OK, 0=KO
+	 *  @return int		 					1=OK, 0=KO
 	 */
 	function custom_pdf_writelinedesc(&$pdf, $object, $i, $outputlangs, $w, $h, $posx, $posy, $hideref = 0, $hidedesc = 0, $issupplierline = 0)
 	{
@@ -338,13 +338,13 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 
 	/**
-     *  Prepare array with the values per ColName
-     *
-     *  @param		Object Facture		$object				Object to generate
-     *  @param 		int 				$i 					Index of current line 
-     *  @param		Translate			$outputlangs		Lang output object
-     *  @param		int					$hidedetails		Do not show line details
-     *  @return     array         	    					The array resulting, with the values to print
+	 *  Prepare array with the values per ColName
+	 *
+	 *  @param		Object Facture		$object				Object to generate
+	 *  @param 		int 				$i 					Index of current line
+	 *  @param		Translate			$outputlangs		Lang output object
+	 *  @param		int					$hidedetails		Do not show line details
+	 *  @return	 array		 							The array resulting, with the values to print
 	 */
 	function get_values_for_line($object, $i, $outputlangs, $hidedetails = 0)
 	{
@@ -361,7 +361,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		// Total price
 		$total_HT = $marg_prog == 0 ? price(0) : pdf_getlinetotalexcltax($object, $i, $outputlangs, $hidedetails);
 		
-		/* Fill Array */    				
+		/* Fill Array */					
 		$values = array(
 			'Designation' => '',
 			'VAT' => pdf_getlinevatrate($object, $i, $outputlangs, $hidedetails),
@@ -402,7 +402,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			}
 			if (TSubtotal::isSubtotal($object->lines[$i])) {
 				$sum = 0;
-				for ($j=1; $j <= $i; $j++) { 
+				for ($j=1; $j <= $i; $j++) {
 					// Sum all the values in lines before the current total, until we reach a Title
 					$l = $object->lines[$i-$j];
 					if (TSubtotal::isTitle($l)) { break; }
@@ -422,15 +422,15 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 
 	/**
-     *  Function to build pdf onto disk
-     *
-     *  @param		Object		$object				Object to generate
-     *  @param		Translate	$outputlangs		Lang output object
-     *  @param		string		$srctemplatepath	Full path of source filename for generator using a template file
-     *  @param		int			$hidedetails		Do not show line details
-     *  @param		int			$this->hidedesc			Do not show desc
-     *  @param		int			$this->hideref			Do not show ref
-     *  @return     int         	    			1=OK, 0=KO
+	 *  Function to build pdf onto disk
+	 *
+	 *  @param		Object		$object				Object to generate
+	 *  @param		Translate	$outputlangs		Lang output object
+	 *  @param		string		$srctemplatepath	Full path of source filename for generator using a template file
+	 *  @param		int			$hidedetails		Do not show line details
+	 *  @param		int			$this->hidedesc			Do not show desc
+	 *  @param		int			$this->hideref			Do not show ref
+	 *  @return	 int		 					1=OK, 0=KO
 	 */
 	function write_file($object, $outputlangs, $srctemplatepath='', $hidedetails=0, $hidedesc=0, $hideref=0)
 	{
@@ -480,7 +480,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 			/* File exists, we create PDF */
 			if (file_exists($dir)) {
-				// Pdfgeneration hook 
+				// Pdfgeneration hook
 				if (! is_object($hookmanager)) {
 					include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
 					$hookmanager=new HookManager($this->db);
@@ -488,7 +488,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 				$hookmanager->initHooks(array('pdfgeneration'));
 				$parameters = array('file' => $file, 'object' => $object, 'outputlangs' => $outputlangs);
 				global $action;
-				$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);    // Note that $action and $object may have been modified by some hooks
+				$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);	// Note that $action and $object may have been modified by some hooks
 
 				// Set nblignes with the new facture lines content after hook
 				$nblignes = count($object->lines);
@@ -496,21 +496,21 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 				// Create pdf instance
 				$pdf=pdf_getInstance($this->format);
-                $default_font_size = pdf_getPDFFontSize($outputlangs);	// Must be after pdf_getInstance
-                $pdf->SetAutoPageBreak(1,0);
-                if (class_exists('TCPDF')) {
-                    $pdf->setPrintHeader(false);
-                    $pdf->setPrintFooter(false);
-                }
-                $pdf->SetFont('', '', $default_font_size);
+				$default_font_size = pdf_getPDFFontSize($outputlangs);	// Must be after pdf_getInstance
+				$pdf->SetAutoPageBreak(1,0);
+				if (class_exists('TCPDF')) {
+					$pdf->setPrintHeader(false);
+					$pdf->setPrintFooter(false);
+				}
+				$pdf->SetFont('', '', $default_font_size);
 
-                // Set path to the background PDF File
-                if (!getDolGlobalInt('MAIN_DISABLE_FPDI') && getDolGlobalInt('MAIN_ADD_PDF_BACKGROUND')) {
-				    $pagecount = $pdf->setSourceFile($conf->mycompany->dir_output.'/' . getDolGlobalString('MAIN_ADD_PDF_BACKGROUND'));
-				    $tplidx = $pdf->importPage(1);
-                }
+				// Set path to the background PDF File
+				if (!getDolGlobalInt('MAIN_DISABLE_FPDI') && getDolGlobalInt('MAIN_ADD_PDF_BACKGROUND')) {
+					$pagecount = $pdf->setSourceFile($conf->mycompany->dir_output.'/' . getDolGlobalString('MAIN_ADD_PDF_BACKGROUND'));
+					$tplidx = $pdf->importPage(1);
+				}
 
-                // Initialize PDF
+				// Initialize PDF
 				$pdf->Open();
 				$pdf->SetDrawColor(128,128,128);
 				$pdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
@@ -632,7 +632,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 				$hookmanager->initHooks(array('pdfgeneration'));
 				$parameters = array('file' => $file, 'object' => $object, 'outputlangs' => $outputlangs);
 				global $action;
-				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);    // Note that $action and $object may have been modified by some hooks
+				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);	// Note that $action and $object may have been modified by some hooks
 
 				if (!empty(getDolGlobalString('MAIN_UMASK')))
 				@chmod($file, octdec(getDolGlobalString('MAIN_UMASK')));
@@ -641,7 +641,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			else
 			{
 				$this->error=$langs->transnoentities("ErrorCanNotCreateDir",$dir);
-				return 0; 
+				return 0;
 			}
 		}
 		else {
@@ -657,20 +657,20 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	/**
 	 *  Show payments table
 	 *
-     *  @param	PDF			$pdf           Object PDF
-     *  @param  Object		$object         Object invoice
-     *  @param  int			$posy           Position y in PDF
-     *  @param  Translate	$outputlangs    Object langs for output
-     *  @return int             			<0 if KO, >0 if OK
+	 *  @param	PDF			$pdf		   Object PDF
+	 *  @param  Object		$object		 Object invoice
+	 *  @param  int			$posy		   Position y in PDF
+	 *  @param  Translate	$outputlangs	Object langs for output
+	 *  @return int			 			<0 if KO, >0 if OK
 	 */
 	function _tableau_versements(&$pdf, $object, $posy, $outputlangs)
 	{
 		global $conf;
 
-        $this->sign=1;
-        if ($object->type == 2 && getDolGlobalInt('INVOICE_POSITIVE_CREDIT_NOTE')) $this->sign=-1;
+		$this->sign=1;
+		if ($object->type == 2 && getDolGlobalInt('INVOICE_POSITIVE_CREDIT_NOTE')) $this->sign=-1;
 
-        $tab3_posx = 120;
+		$tab3_posx = 120;
 		$tab3_top = $posy + 8;
 		$tab3_width = 80;
 		$tab3_height = 4;
@@ -797,7 +797,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	/**
 	 *   Show miscellaneous information (payment mode, payment term, ...)
 	 *
-	 *   @param		PDF			$pdf     		Object PDF
+	 *   @param		PDF			$pdf	 		Object PDF
 	 *   @param		Object		$object			Object to show
 	 *   @param		int			$posy			Y
 	 *   @param		Translate	$outputlangs	Langs object
@@ -901,13 +901,13 @@ class pdf_couffignal_situation extends ModelePDFFactures
 						$pdf->MultiCell(100, 3, $outputlangs->transnoentities('PaymentByChequeOrderedTo',$account->proprio),0,'L',0);
 						$posy=$pdf->GetY()+1;
 
-			            if (!getDolGlobalInt('MAIN_PDF_HIDE_CHQ_ADDRESS'))
-			            {
+						if (!getDolGlobalInt('MAIN_PDF_HIDE_CHQ_ADDRESS'))
+						{
 							$pdf->SetXY($this->margin_left, $posy);
 							$pdf->SetFont('','', $default_font_size - $diffsizetitle);
 							$pdf->MultiCell(100, 3, $outputlangs->convToOutputCharset($account->owner_address), 0, 'L', 0);
 							$posy=$pdf->GetY()+2;
-			            }
+						}
 					}
 					if (getDolGlobalInt('FACTURE_CHQ_NUMBER') == -1)
 					{
@@ -916,13 +916,13 @@ class pdf_couffignal_situation extends ModelePDFFactures
 						$pdf->MultiCell(100, 3, $outputlangs->transnoentities('PaymentByChequeOrderedTo',$this->issuer->name),0,'L',0);
 						$posy=$pdf->GetY()+1;
 
-			            if (!getDolGlobalInt('MAIN_PDF_HIDE_CHQ_ADDRESS'))
-			            {
+						if (!getDolGlobalInt('MAIN_PDF_HIDE_CHQ_ADDRESS'))
+						{
 							$pdf->SetXY($this->margin_left, $posy);
 							$pdf->SetFont('','', $default_font_size - $diffsizetitle);
 							$pdf->MultiCell(100, 3, $outputlangs->convToOutputCharset($this->issuer->getFullAddress()), 0, 'L', 0);
 							$posy=$pdf->GetY()+2;
-			            }
+						}
 					}
 				}
 			}
@@ -953,12 +953,12 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	/**
 	 *	Show main detailed lines
 	 *
-	 *	@param	PDF			$pdf            (ref) Object PDF
-	 *	@param  Facture		$object         Object invoice
+	 *	@param	PDF			$pdf			(ref) Object PDF
+	 *	@param  Facture		$object		 Object invoice
 	 *	@param	Translate	$outputlangs	Objet langs
 	 *  @param	int			$tab_top		Top position y of the table
 	 *  @param	int			$bottomlasttab	(ref) Bottom position y of the lasttable
-	 * 
+	 *
 	 *	@return int							OK=1; NOK=0
 	 */
 	function _main_table(&$pdf, $object, &$bottomlasttab, $outputlangs, $tab_top, $hidedetails) {
@@ -1004,7 +1004,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 			// Retrieve type from database for backward compatibility with old records
 			if ((! isset($localtax1_type) || $localtax1_type=='' || ! isset($localtax2_type) || $localtax2_type=='') // if tax type not defined
-			&& (! empty($localtax1_rate) || ! empty($localtax2_rate))) { // and there is local tax 
+			&& (! empty($localtax1_rate) || ! empty($localtax2_rate))) { // and there is local tax
 				$localtaxtmp_array=getLocalTaxesFromRate($vatrate,0, $object->thirdparty, $mysoc);
 				$localtax1_type = $localtaxtmp_array[0];
 				$localtax2_type = $localtaxtmp_array[2];
@@ -1098,25 +1098,25 @@ class pdf_couffignal_situation extends ModelePDFFactures
 				$pdf->line($this->margin_left, $nexY + 1, $this->page_width - $this->margin_right, $nexY + 1);
 				$pdf->SetLineStyle(array('dash'=>0));
 			}
-			$nexY += 2;    // Passe espace entre les lignes
+			$nexY += 2;	// Passe espace entre les lignes
 
 			$curY = $nexY;
 		}
 
 		/*** Last page ***/
-		// If the last line was to large to be on the last page but small enough to fit on a normal page, we need to add the final page (whose table will be empty) 
+		// If the last line was to large to be on the last page but small enough to fit on a normal page, we need to add the final page (whose table will be empty)
 		if (!$can_be_last_page && $can_be_on_normal_page) {
 			$tab_height_in_page[$origin_page] = $curY;
 			$pdf->AddPage();
 			if (!empty($tplidx)) $pdf->useTemplate($tplidx);
 			if (!getDolGlobalInt('MAIN_PDF_DONOTREPEAT_HEAD')) $this->_pagehead($pdf, $object, 0, $outputlangs);
-		} 
+		}
 		$pdf->setPageOrientation('L', 1, ($this->heightforinfotot - $this->heightforfreetext - $this->heightforfooter));	// The only function to edit the bottom margin of current page to set it.
 
 		
 		/***** Grid for all pages but the last one *****/
 		$nb_page = $pdf->getPage();
-		for ($p=2; $p < $nb_page; $p++) { 
+		for ($p=2; $p < $nb_page; $p++) {
 			$pdf->setPage($p);
 			$this->_grid_and_title($pdf, $tab_top, $tab_height_in_page[$p], 0, $outputlangs, 0, 1, $object->multicurrency_code);
 		}
@@ -1130,9 +1130,9 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	/**
 	 *	Show total to pay
 	 *
-	 *	@param	PDF			$pdf           Object PDF
-	 *	@param  Facture		$object         Object invoice
-	 *	@param  int			$deja_regle     Montant deja regle
+	 *	@param	PDF			$pdf		   Object PDF
+	 *	@param  Facture		$object		 Object invoice
+	 *	@param  int			$deja_regle	 Montant deja regle
 	 *	@param	int			$posy			Position depart
 	 *	@param	Translate	$outputlangs	Objet langs
 	 *	@return int							Position pour suite
@@ -1141,10 +1141,10 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	{
 		global $conf,$mysoc;
 
-        $this->sign=1;
-        if ($object->type == 2 && getDolGlobalInt('INVOICE_POSITIVE_CREDIT_NOTE')) $this->sign=-1;
+		$this->sign=1;
+		if ($object->type == 2 && getDolGlobalInt('INVOICE_POSITIVE_CREDIT_NOTE')) $this->sign=-1;
 
-        $default_font_size = pdf_getPDFFontSize($outputlangs);
+		$default_font_size = pdf_getPDFFontSize($outputlangs);
 
 		$tab2_top = $posy;
 		$tab2_hl = 4;
@@ -1162,11 +1162,11 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$totalAvancement = 0;
 		// TODO AMA -- Remplacer avec un appel au global progress over invoice.
 		foreach ($object->lines as $line) {
-		    if(!class_exists('TSubtotal') || !TSubtotal::isModSubtotalLine($line)){
+			if(!class_exists('TSubtotal') || !TSubtotal::isModSubtotalLine($line)){
 				$divider = $line->situation_percent > 0 ? $line->situation_percent / 100  : 1;
-		        $totalFacture += $line->total_ht /  $divider;
-		        $totalAvancement+=$line->total_ht;
-		    }
+				$totalFacture += $line->total_ht /  $divider;
+				$totalAvancement+=$line->total_ht;
+			}
 		}
 		if (!empty($totalFacture)) $avancementGlobal = $totalAvancement / $totalFacture * 100;
 		else $avancementGlobal = 0;
@@ -1178,31 +1178,31 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		// Compute amount to be paid
 		$total_a_payer = 0;
 		foreach ($TPreviousInvoice as &$fac) {
-		    $total_a_payer += $fac->total_ht;
+			$total_a_payer += $fac->total_ht;
 		}
 		$total_a_payer += $object->total_ht;
 
 		if (empty($avancementGlobal)) {
-		    $total_a_payer = 0;
+			$total_a_payer = 0;
 		} else {
-		    $total_a_payer = $total_a_payer * 100 / $avancementGlobal;
+			$total_a_payer = $total_a_payer * 100 / $avancementGlobal;
 		}
 
 		// Todo : Fix incorrect amount later on
 		/*if(!empty($TPreviousInvoice)){
-		    $pdf->setY($tab2_top);
-		    $posy = $pdf->GetY();
+			$pdf->setY($tab2_top);
+			$posy = $pdf->GetY();
 
-		    $pdf->SetFont('','', $default_font_size - 1);
-		    $pdf->SetFillColor(255,255,255);
-		    $pdf->SetXY($col1x, $posy);
-		    $pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("BtpTotalProgress", $avancementGlobal), 0, 'L', 1);
+			$pdf->SetFont('','', $default_font_size - 1);
+			$pdf->SetFillColor(255,255,255);
+			$pdf->SetXY($col1x, $posy);
+			$pdf->MultiCell($col2x-$col1x, $tab2_hl, $outputlangs->transnoentities("BtpTotalProgress", $avancementGlobal), 0, 'L', 1);
 
-		    $pdf->SetXY($col2x,$posy);
-		    $pdf->MultiCell($largcol2, $tab2_hl, price($total_a_payer*$avancementGlobal/100, 0, $outputlangs), 0, 'R', 1);
-		    $pdf->SetFont('','', $default_font_size - 2);
+			$pdf->SetXY($col2x,$posy);
+			$pdf->MultiCell($largcol2, $tab2_hl, price($total_a_payer*$avancementGlobal/100, 0, $outputlangs), 0, 'R', 1);
+			$pdf->SetFont('','', $default_font_size - 2);
 
-		    $posy += $tab2_hl;
+			$posy += $tab2_hl;
 
 			$last_invoice = end($TPreviousInvoice);
 			$posy = $this->setNewPage($posy, $pdf, $object, $outputlangs, 180);
@@ -1221,7 +1221,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			$posy += $tab2_hl;
 			$pdf->setY($posy);
 			$posy = $this->setNewPage($posy,  $pdf, $object, $outputlangs);
-		    $tab2_top = $posy;
+			$tab2_top = $posy;
 		}*/
 
 		$special_endline = $object->marginal_special_lines($outputlangs);
@@ -1294,7 +1294,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 						$pdf->MultiCell($col2x-$col1x, $tab2_hl, $totalvat, 0, 'L', 1);
 
 						$pdf->SetXY($col2x, $tab2_top + $tab2_hl * $index);
-						$tva_prorata = ((float) $tvaval) * ($object->prorata_rate / 100); 
+						$tva_prorata = ((float) $tvaval) * ($object->prorata_rate / 100);
 						$tvaval = $tvaval - $tva_prorata;
 						$pdf->MultiCell($largcol2, $tab2_hl, price(round($tvaval, 2), 0, $outputlangs), 0, 'R', 1);
 						$total_ttc -= $tva_prorata;
@@ -1387,7 +1387,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	/**
 	 *   Show table for lines, full size except margins
 	 *
-	 *   @param		PDF			$pdf     		Object PDF
+	 *   @param		PDF			$pdf	 		Object PDF
 	 *   @param		string		$tab_top		Top position of table
 	 *   @param		string		$tab_height		Height of table (rectangle)
 	 *   @param		int			$nexY			Y (not used)
@@ -1421,7 +1421,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		}
 		
 		/** Support for background Color Check if not elsewhere **/
-		/*if (getDolGlobalString('MAIN_PDF_TITLE_BACKGROUND_COLOR')) 
+		/*if (getDolGlobalString('MAIN_PDF_TITLE_BACKGROUND_COLOR'))
 			$pdf->Rect($this->margin_left, $tab_top_incl_header, $this->page_width-$this->margin_right-$this->margin_left, 5, 'F', null, explode(',',getDolGlobalString('MAIN_PDF_TITLE_BACKGROUND_COLOR')));*/
 
 		/*** Grid ***/
@@ -1445,7 +1445,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	/**
 	 *   Show table BTP
 	 *
-	 *   @param		PDF			$pdf     		Object PDF
+	 *   @param		PDF			$pdf	 		Object PDF
 	 *   @param		string		$tab_top		Top position of table
 	 *   @param		string		$tab_height		Height of table (rectangle)
 	 *   @param		int			$nexY			Y (not used)
@@ -1525,7 +1525,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 				'title' => $outputlangs->transnoentities("Situation") . ' '. $object->situation_counter,
 				'startX' => $this->posx_month-1,
 			)
-		); 
+		);
 
 		/** Display **/
 		$pdf->SetDrawColor(128,128,128);
@@ -1552,9 +1552,9 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			$posy += $line['spaceAfter'];
 			if ($line['Hline']) {
 				$pdf->line(
-					$line['Hline'] == 'full' ? $this->margin_left : $this->posx_new_cumul-1, 
-					$posy, 
-					$this->page_width - $this->margin_right, 
+					$line['Hline'] == 'full' ? $this->margin_left : $this->posx_new_cumul-1,
+					$posy,
+					$this->page_width - $this->margin_right,
 					$posy
 				);
 			}
@@ -1594,7 +1594,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$nouveau_cumul = $cumul_anterieur_ht + $object->total_ht;
 		$nouveau_cumul_tva = $cumul_anterieur_tva + $object->total_tva;
 
-		// Prepare lines for recap table 
+		// Prepare lines for recap table
 		$travaux_total = $object->totalExeptSpecialLines();
 		$travaux_cum_total = $facDerniereSituation ? $facDerniereSituation->totalExeptSpecialLines() : 0;
 		$recap_lines = array();
@@ -1610,7 +1610,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 				'NewCumul' => price($travaux_total),
 				'PrevCumul' => price($travaux_cum_total),
 				'Situation' => price($travaux_total - $travaux_cum_total),
-			), 
+			),
 		);
 
 		// Merge/Cumul special_lines
@@ -1746,7 +1746,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		if ($uselocaltax1_rate < 0) $uselocaltax1_rate=$seller->localtax1_assuj;
 		if ($uselocaltax2_rate < 0) $uselocaltax2_rate=$seller->localtax2_assuj;
 
-	    // Now we search localtaxes information ourself (rates and types).
+		// Now we search localtaxes information ourself (rates and types).
 		$localtax1_type=0;
 		$localtax2_type=0;
 
@@ -1781,44 +1781,44 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		}
 		// initialize total (may be HT or TTC depending on price_base_type)
 		$tot_sans_remise = $pu * $qty;
-		$tot_avec_remise_ligne = $tot_sans_remise       * (1 - ($remise_percent_ligne / 100));
-		$tot_avec_remise       = $tot_avec_remise_ligne * (1 - ($remise_percent_global / 100));
+		$tot_avec_remise_ligne = $tot_sans_remise	   * (1 - ($remise_percent_ligne / 100));
+		$tot_avec_remise	   = $tot_avec_remise_ligne * (1 - ($remise_percent_global / 100));
 
 		// initialize result array
 		for ($i=0; $i <= 15; $i++) $result[$i] = 0;
 
 		// if there's some localtax including vat, we calculate localtaxes (we will add later)
 
-	    //If input unit price is 'HT', we need to have the totals with main VAT for a correct calculation
-	    if ($price_base_type != 'TTC')
-	    {
-	    	$tot_sans_remise_wt = price2num($tot_sans_remise * (1 + ($txtva / 100)),'MU');
-	    	$tot_avec_remise_wt = price2num($tot_avec_remise * (1 + ($txtva / 100)),'MU');
-	    	$pu_wt = price2num($pu * (1 + ($txtva / 100)),'MU');
-	    }
-	    else
-	    {
-	    	$tot_sans_remise_wt = $tot_sans_remise;
-	    	$tot_avec_remise_wt = $tot_avec_remise;
-	    	$pu_wt = $pu;
-	    }
+		//If input unit price is 'HT', we need to have the totals with main VAT for a correct calculation
+		if ($price_base_type != 'TTC')
+		{
+			$tot_sans_remise_wt = price2num($tot_sans_remise * (1 + ($txtva / 100)),'MU');
+			$tot_avec_remise_wt = price2num($tot_avec_remise * (1 + ($txtva / 100)),'MU');
+			$pu_wt = price2num($pu * (1 + ($txtva / 100)),'MU');
+		}
+		else
+		{
+			$tot_sans_remise_wt = $tot_sans_remise;
+			$tot_avec_remise_wt = $tot_avec_remise;
+			$pu_wt = $pu;
+		}
 
 		//print 'rr'.$price_base_type.'-'.$txtva.'-'.$tot_sans_remise_wt."-".$pu_wt."-".$uselocaltax1_rate."-".$localtax1_rate."-".$localtax1_type."\n";
 
-	    $localtaxes = array(0,0,0);
-	    $apply_tax = false;
+		$localtaxes = array(0,0,0);
+		$apply_tax = false;
 	  	switch($localtax1_type) {
-	      case '2':     // localtax on product or service
-	        $apply_tax = true;
-	        break;
-	      case '4':     // localtax on product
-	        if ($type == 0) $apply_tax = true;
-	        break;
-	      case '6':     // localtax on service
-	        if ($type == 1) $apply_tax = true;
-	        break;
-	    }
-	    if ($uselocaltax1_rate && $apply_tax) {
+		  case '2':	 // localtax on product or service
+			$apply_tax = true;
+			break;
+		  case '4':	 // localtax on product
+			if ($type == 0) $apply_tax = true;
+			break;
+		  case '6':	 // localtax on service
+			if ($type == 1) $apply_tax = true;
+			break;
+		}
+		if ($uselocaltax1_rate && $apply_tax) {
 	  		$result[14] = price2num(($tot_sans_remise_wt * (1 + ( $localtax1_rate / 100))) - $tot_sans_remise_wt, 'MT');
 	  		$localtaxes[0] += $result[14];
 
@@ -1827,21 +1827,21 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 	  		$result[11] = price2num(($pu_wt * (1 + ( $localtax1_rate / 100))) - $pu_wt, 'MU');
 	  		$localtaxes[2] += $result[11];
-	    }
+		}
 
-	    $apply_tax = false;
+		$apply_tax = false;
 	  	switch($localtax2_type) {
-	      case '2':     // localtax on product or service
-	        $apply_tax = true;
-	        break;
-	      case '4':     // localtax on product
-	        if ($type == 0) $apply_tax = true;
-	        break;
-	      case '6':     // localtax on service
-	        if ($type == 1) $apply_tax = true;
-	        break;
-	    }
-	    if ($uselocaltax2_rate && $apply_tax) {
+		  case '2':	 // localtax on product or service
+			$apply_tax = true;
+			break;
+		  case '4':	 // localtax on product
+			if ($type == 0) $apply_tax = true;
+			break;
+		  case '6':	 // localtax on service
+			if ($type == 1) $apply_tax = true;
+			break;
+		}
+		if ($uselocaltax2_rate && $apply_tax) {
 	  		$result[15] = price2num(($tot_sans_remise_wt * (1 + ( $localtax2_rate / 100))) - $tot_sans_remise_wt, 'MT');
 	  		$localtaxes[0] += $result[15];
 
@@ -1850,7 +1850,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 	  		$result[12] = price2num(($pu_wt * (1 + ( $localtax2_rate / 100))) - $pu_wt, 'MU');
 	  		$localtaxes[2] += $result[12];
-	    }
+		}
 
 		//dol_syslog("price.lib::calcul_price_total $qty, $pu, $remise_percent_ligne, $txtva, $price_base_type $info_bits");
 		if ($price_base_type == 'HT')
@@ -1892,27 +1892,27 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 		// if there's some localtax without vat, we calculate localtaxes (we will add them at end)
 
-	    //If input unit price is 'TTC', we need to have the totals without main VAT for a correct calculation
-	    if ($price_base_type == 'TTC')
-	    {
-	    	$tot_sans_remise= price2num($tot_sans_remise / (1 + ($txtva / 100)),'MU');
-	    	$tot_avec_remise= price2num($tot_avec_remise / (1 + ($txtva / 100)),'MU');
-	    	$pu = price2num($pu / (1 + ($txtva / 100)),'MU');
-	    }
+		//If input unit price is 'TTC', we need to have the totals without main VAT for a correct calculation
+		if ($price_base_type == 'TTC')
+		{
+			$tot_sans_remise= price2num($tot_sans_remise / (1 + ($txtva / 100)),'MU');
+			$tot_avec_remise= price2num($tot_avec_remise / (1 + ($txtva / 100)),'MU');
+			$pu = price2num($pu / (1 + ($txtva / 100)),'MU');
+		}
 
 		$apply_tax = false;
-	    switch($localtax1_type) {
-	      case '1':     // localtax on product or service
-	        $apply_tax = true;
-	        break;
-	      case '3':     // localtax on product
-	        if ($type == 0) $apply_tax = true;
-	        break;
-	      case '5':     // localtax on service
-	        if ($type == 1) $apply_tax = true;
-	        break;
-	    }
-	    if ($uselocaltax1_rate && $apply_tax) {
+		switch($localtax1_type) {
+		  case '1':	 // localtax on product or service
+			$apply_tax = true;
+			break;
+		  case '3':	 // localtax on product
+			if ($type == 0) $apply_tax = true;
+			break;
+		  case '5':	 // localtax on service
+			if ($type == 1) $apply_tax = true;
+			break;
+		}
+		if ($uselocaltax1_rate && $apply_tax) {
 	  		$result[14] = price2num(($tot_sans_remise * (1 + ( $localtax1_rate / 100))) - $tot_sans_remise, 'MT');	// amount tax1 for total_ht_without_discount
 	  		$result[8] += $result[14];																				// total_ttc_without_discount + tax1
 
@@ -1921,21 +1921,21 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 	  		$result[11] = price2num(($pu * (1 + ( $localtax1_rate / 100))) - $pu, 'MU');							// amount tax1 for pu_ht
 	  		$result[5] += $result[11];																				// pu_ht + tax1
-	    }
+		}
 
-	    $apply_tax = false;
+		$apply_tax = false;
 	  	switch($localtax2_type) {
-	      case '1':     // localtax on product or service
-	        $apply_tax = true;
-	        break;
-	      case '3':     // localtax on product
-	        if ($type == 0) $apply_tax = true;
-	        break;
-	      case '5':     // localtax on service
-	        if ($type == 1) $apply_tax = true;
-	        break;
-	    }
-	    if ($uselocaltax2_rate && $apply_tax) {
+		  case '1':	 // localtax on product or service
+			$apply_tax = true;
+			break;
+		  case '3':	 // localtax on product
+			if ($type == 0) $apply_tax = true;
+			break;
+		  case '5':	 // localtax on service
+			if ($type == 1) $apply_tax = true;
+			break;
+		}
+		if ($uselocaltax2_rate && $apply_tax) {
 	  		$result[15] = price2num(($tot_sans_remise * (1 + ( $localtax2_rate / 100))) - $tot_sans_remise, 'MT');	// amount tax2 for total_ht_without_discount
 	  		$result[8] += $result[15];																				// total_ttc_without_discount + tax2
 
@@ -1944,11 +1944,11 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 	  		$result[12] = price2num(($pu * (1 + ( $localtax2_rate / 100))) - $pu, 'MU');							// amount tax2 for pu_ht
 	  		$result[5] += $result[12];																				// pu_ht + tax2
-	    }
+		}
 
 		// If rounding is not using base 10 (rare)
 		$roundingRule=getDolGlobalInt('MAIN_ROUNDING_RULE_TOT');
-        if ($roundingRule > 0) {
+		if ($roundingRule > 0) {
 			if ($price_base_type == 'HT') {
 				$result[0]  = round($result[0] / $roundingRule, 0) * $roundingRule;
 				$result[1]  = round($result[1] / $roundingRule, 0) * $roundingRule;
@@ -1974,16 +1974,16 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 	/**
 	 * Show one line in the References part
-	 * 	@param	PDF			$pdf     		Object PDF
-	 *  @param  int			$w     			Width of writing cell
-	 *  @param  int			$posx     		Position in x
-	 *  @param  int			$posy     		Position in y
-	 *  @param  str	    	$label    		Text to show
-	 *  @param  int			$fontSize     	Font size in pt
-	 *	@param  str	    	$fontWeight    	Font Weight ('' or 'B')
-	 *  @param  int			$spaceBefore    Space, in point, to add before line
-	 *  @param  int			$spaceAfter     Space, in point, to add after line
-	 * 
+	 * 	@param	PDF			$pdf	 		Object PDF
+	 *  @param  int			$w	 			Width of writing cell
+	 *  @param  int			$posx	 		Position in x
+	 *  @param  int			$posy	 		Position in y
+	 *  @param  str			$label			Text to show
+	 *  @param  int			$fontSize	 	Font size in pt
+	 *	@param  str			$fontWeight		Font Weight ('' or 'B')
+	 *  @param  int			$spaceBefore	Space, in point, to add before line
+	 *  @param  int			$spaceAfter	 Space, in point, to add after line
+	 *
 	 *  @return	int 						posY after printing
 	 */
 	function _display_header_line(&$pdf, $w, $posx, $posy, $label, $fontSize, $fontWeight = '', $spaceBefore = 3, $spaceAfter = 0) {
@@ -1998,9 +1998,9 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	/**
 	 *  Show top header of page.
 	 *
-	 *  @param	PDF			$pdf     		Object PDF
-	 *  @param  Object		$object     	Object to show
-	 *  @param  int	    	$showaddress    0=no, 1=yes
+	 *  @param	PDF			$pdf	 		Object PDF
+	 *  @param  Object		$object	 	Object to show
+	 *  @param  int			$showaddress	0=no, 1=yes
 	 *  @param  Translate	$outputlangs	Object lang for output
 	 *  @param  boolean  $showLinkedObject
 	 *  @return	void
@@ -2021,8 +2021,8 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 		// Show Draft Watermark
 		if($object->statut == 0 && (!empty(getDolGlobalString('FACTURE_DRAFT_WATERMARK')))) {
-		      pdf_watermark($pdf,$outputlangs,$this->page_height,$this->page_width,'mm',getDolGlobalString('FACTURE_DRAFT_WATERMARK'));
-        }
+			  pdf_watermark($pdf,$outputlangs,$this->page_height,$this->page_width,'mm',getDolGlobalString('FACTURE_DRAFT_WATERMARK'));
+		}
 
 		$pdf->SetTextColor(0,0,60);
 		$pdf->SetFont('','B', $default_font_size + 3);
@@ -2030,7 +2030,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$w = 110;
 
 		$posy = $this->marge_haute;
-        $posx = $this->page_width-$this->margin_right-$w;
+		$posx = $this->page_width-$this->margin_right-$w;
 
 		$pdf->SetXY($this->margin_left,$posy);
 
@@ -2038,7 +2038,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$logo=$conf->mycompany->dir_output.'/logos/'.$this->issuer->logo;
 		if ($this->issuer->logo) {
 			if (is_readable($logo)) {
-			    $height = pdf_getHeightForLogo($logo);
+				$height = pdf_getHeightForLogo($logo);
 				$pdf->Image($logo, $this->margin_left, $posy, 0, $height);	// width=0 (auto)
 			} else {
 				$pdf->SetTextColor(200, 0, 0);
@@ -2061,20 +2061,20 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$lines = array(
 			'Ref' => array(
 				'spaceBefore' => 5,
-				'label' => $title . ' ' . $outputlangs->convToOutputCharset($object->ref), 
+				'label' => $title . ' ' . $outputlangs->convToOutputCharset($object->ref),
 				'fontWeight' => 'B',
 				'fontSize' => $default_font_size + 3,
 			),
 			'SituationNbr' => array(
 				'spaceBefore' => 5,
-				'label' => $outputlangs->transnoentities("PDFCrabeBtpTitle", $object->situation_counter), 
+				'label' => $outputlangs->transnoentities("PDFCrabeBtpTitle", $object->situation_counter),
 				'spaceAfter' => 1,
 				'fontWeight' => 'B',
 				'fontSize' => $default_font_size,
 			),
 			'DateInvoice' => array(
 				'spaceBefore' => 4,
-				'label' => $outputlangs->transnoentities("DateInvoice")." : " . dol_print_date($object->date,"day",false,$outputlangs), 
+				'label' => $outputlangs->transnoentities("DateInvoice")." : " . dol_print_date($object->date,"day",false,$outputlangs),
 				'fontSize' => $default_font_size - 2,
 			),
 		);
@@ -2082,7 +2082,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		if ($object->ref_client) {
 			$lines['RefClient'] = array(
 				'spaceBefore' => 4,
-				'label' => $outputlangs->transnoentities("RefCustomer")." : " . $outputlangs->convToOutputCharset($object->ref_client), 
+				'label' => $outputlangs->transnoentities("RefCustomer")." : " . $outputlangs->convToOutputCharset($object->ref_client),
 				'fontSize' => $default_font_size - 2,
 			);
 		}
@@ -2091,7 +2091,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			$objectreplacing = new Facture($this->db);
 			$objectreplacing->fetch($objectidnext);
 			$lines['ReplacementBy'] = array(
-				'label' => $outputlangs->transnoentities("ReplacementByInvoice").' : '.$outputlangs->convToOutputCharset($objectreplacing->ref), 
+				'label' => $outputlangs->transnoentities("ReplacementByInvoice").' : '.$outputlangs->convToOutputCharset($objectreplacing->ref),
 				'fontSize' => $default_font_size - 2,
 			);
 		}
@@ -2100,7 +2100,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			$objectreplaced->fetch($object->fk_facture_source);
 			$lines['ReplacementInvoice'] = array(
 				'spaceBefore' => 4,
-				'label' => $outputlangs->transnoentities("ReplacementInvoice").' : '.$outputlangs->convToOutputCharset($objectreplaced->ref), 
+				'label' => $outputlangs->transnoentities("ReplacementInvoice").' : '.$outputlangs->convToOutputCharset($objectreplaced->ref),
 				'fontSize' => $default_font_size - 2,
 			);
 		}
@@ -2108,26 +2108,26 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			$objectreplaced = new Facture($this->db);
 			$objectreplaced->fetch($object->fk_facture_source);
 			$lines['CorrectionInvoice'] = array(
-				'label' => $outputlangs->transnoentities("CorrectionInvoice").' : '.$outputlangs->convToOutputCharset($objectreplaced->ref), 
+				'label' => $outputlangs->transnoentities("CorrectionInvoice").' : '.$outputlangs->convToOutputCharset($objectreplaced->ref),
 				'fontSize' => $default_font_size - 2,
 			);
 		}
 		if (getDolGlobalInt('INVOICE_POINTOFTAX_DATE')) {
 			$lines['DatePointOfTax'] = array(
 				'spaceBefore' => 4,
-				'label' => $outputlangs->transnoentities("DatePointOfTax")." : " . dol_print_date($object->date_pointoftax,"day",false,$outputlangs), 
+				'label' => $outputlangs->transnoentities("DatePointOfTax")." : " . dol_print_date($object->date_pointoftax,"day",false,$outputlangs),
 				'fontSize' => $default_font_size - 2,
 			);
 		}
 		if ($object->type != 2)	{
 			$lines['DateDue'] = array(
-				'label' => $outputlangs->transnoentities("DateDue")." : " . dol_print_date($object->date_lim_reglement,"day",false,$outputlangs,true), 
+				'label' => $outputlangs->transnoentities("DateDue")." : " . dol_print_date($object->date_lim_reglement,"day",false,$outputlangs,true),
 				'fontSize' => $default_font_size - 2,
 			);
 		}
 		if ($object->thirdparty->code_client) {
 			$lines['CustomerCode'] = array(
-				'label' => $outputlangs->transnoentities("CustomerCode")." : " . $outputlangs->transnoentities($object->thirdparty->code_client), 
+				'label' => $outputlangs->transnoentities("CustomerCode")." : " . $outputlangs->transnoentities($object->thirdparty->code_client),
 				'fontSize' => $default_font_size - 2,
 			);
 		}
@@ -2233,12 +2233,12 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 	/**
 	 *   	Show footer of page. Need this->issuer object
-     *
-	 *   	@param	PDF			$pdf     			PDF
+	 *
+	 *   	@param	PDF			$pdf	 			PDF
 	 * 		@param	Object		$object				Object to show
-	 *      @param	Translate	$outputlangs		Object lang for output
-	 *      @param	int			$hidefreetext		1=Hide free text
-	 *      @return	int								Return height of bottom margin including footer text
+	 *	  @param	Translate	$outputlangs		Object lang for output
+	 *	  @param	int			$hidefreetext		1=Hide free text
+	 *	  @return	int								Return height of bottom margin including footer text
 	 */
 	function _pagefoot(&$pdf, $object, $outputlangs, $hidefreetext = 0)
 	{
@@ -2253,20 +2253,20 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	 *
 	 * @param	PDF		$pdf			Object PDF
 	 * @param	float	$x				Abscissa of first point
-	 * @param	float	$y		        Ordinate of first point
+	 * @param	float	$y				Ordinate of first point
 	 * @param	float	$l				??
 	 * @param	float	$h				??
 	 * @param	int		$hidetop		1=Hide top bar of array and title, 0=Hide nothing, -1=Hide only title
 	 * @param	int		$hidebottom		Hide bottom
 	 * @return	void
 	 */
-    function printRectBtp($pdf, $x, $y, $l, $h, $hidetop = 0, $hidebottom = 0)
-    {
-	    if (empty($hidetop) || $hidetop == -1) $pdf->line($x, $y, $x+$l, $y);
-	    $pdf->line($x+$l, $y, $x+$l, $y+$h);
-	    if (empty($hidebottom)) $pdf->line($x+$l, $y+$h, $x, $y+$h);
-	    $pdf->line($x, $y+$h, $x, $y);
-    }
+	function printRectBtp($pdf, $x, $y, $l, $h, $hidetop = 0, $hidebottom = 0)
+	{
+		if (empty($hidetop) || $hidetop == -1) $pdf->line($x, $y, $x+$l, $y);
+		$pdf->line($x+$l, $y, $x+$l, $y+$h);
+		if (empty($hidebottom)) $pdf->line($x+$l, $y+$h, $x, $y+$h);
+		$pdf->line($x, $y+$h, $x, $y);
+	}
 
 	/**
 	 * @param $posy

--- a/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
@@ -1495,11 +1495,13 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		}
 		
 		/* COUF Custom table */
+		$marche = new Project($db);
+		$marche->fetch($object->fk_projet);
 		$recap_tab_height = 15;
 		$this->printRectBtp($pdf,$this->margin_left, $tab_top, $this->page_width-$this->margin_left-$this->margin_right, $recap_tab_height, $hidetop, $hidebottom);
 		$pdf->SetFont('','B', $default_font_size - 1);
 		$pdf->SetXY($this->margin_left+2, $tab_top+4);
-		$pdf->MultiCell(80,2, $outputlangs->transnoentities("Marché") . ' : '. $outputlangs->convToOutputCharset($object->ref_client),'','L');
+		$pdf->MultiCell(80,2, $outputlangs->transnoentities("Marché") . ' : '. $outputlangs->convToOutputCharset($object->projet->title) . " (" . $object->projet->ref . ")",'','L');
 		$pdf->SetXY($this->margin_left+2, $tab_top+8);
 		$pdf->MultiCell(80,2, $outputlangs->transnoentities("SituationSerieTotal") . ' : '. price($object->getLastSituationCompletePrice()) . ' HT','','L');
 		$pdf->SetFont('','', $default_font_size - 2);

--- a/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
@@ -1495,8 +1495,6 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		}
 		
 		/* COUF Custom table */
-		$marche = new Project($db);
-		$marche->fetch($object->fk_projet);
 		$recap_tab_height = 15;
 		$this->printRectBtp($pdf,$this->margin_left, $tab_top, $this->page_width-$this->margin_left-$this->margin_right, $recap_tab_height, $hidetop, $hidebottom);
 		$pdf->SetFont('','B', $default_font_size - 1);

--- a/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
@@ -59,7 +59,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	var	$marge_haute;
 	var	$margin_bottom;
 
-	var $emetteur;	// Objet societe qui emet
+	var $issuer;	// Object for the issuing company
 
 	/**
 	 * @var bool Situation invoice type
@@ -104,7 +104,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$this->heightforinfotot = $this->margin_bottom + 20;	// Height reserved to output the footer (value include bottom margin)
 
 		$this->option_logo = 1;                    // Affiche logo
-		$this->option_tva = 1;                     // Gere option tva FACTURE_TVAOPTION
+		$this->option_tva = 1;                     // Manage option tva FACTURE_TVAOPTION
 		$this->option_modereg = 1;                 // Affiche mode reglement
 		$this->option_condreg = 1;                 // Affiche conditions reglement
 		$this->option_codeproduitservice = 1;      // Affiche code produit-service
@@ -119,8 +119,8 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 
 		// Define various properties
-		$this->emetteur=$mysoc;
-		if (empty($this->emetteur->country_code)) $this->emetteur->country_code = substr($langs->defaultlang,-2);    // By default, if was not defined
+		$this->issuer=$mysoc;
+		if (empty($this->issuer->country_code)) $this->issuer->country_code = substr($langs->defaultlang,-2);    // By default, if was not defined
 		$this->franchise =! $mysoc->tva_assuj;
 		$this->tva = array();
 		$this->localtax1 = array();
@@ -252,7 +252,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 	/**
      *  Function to compute size of the columns
-     * 	Populate attribute columns in $this with 2nd dimention width & start
+     * 	Populate attribute columns in $this with 2nd dimension width & start
      *
      *  @return     int         	    			1=OK, 0=KO
 	 */
@@ -375,7 +375,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			'TotalHT' => price(round( (float) price2num($total_HT), 2))
 		);
 		if (getDolGlobalInt('PRODUCT_USE_UNITS')) { $values['Unit'] = pdf_getlineunit($object, $i, $outputlangs, $hidedetails, $hookmanager); }
-		// TODO: is the call to Main usefull ?
+		// TODO: is the call to Main useful ?
 
 		/* Manage special lines */
 		// Support lines attributes
@@ -454,7 +454,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 		/**** Prepare file ****/
 		if ($conf->facture->dir_output) {
-			/**** Pepare / Init ****/
+			/**** Prepare / Init ****/
 
 			// Object init
 			$object->fetch_thirdparty();
@@ -570,7 +570,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 					$pdf->Rect($this->margin_left, $tab_top, $note_width, $height_note + 2);
 				}
 
-				/*** Page 2 & followings ***/
+				/*** Page 2 & following ***/
 
 				// Change orientation
 				$pdf->AddPage();
@@ -650,7 +650,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		}
 		
 		$this->error = $langs->transnoentities("ErrorUnknown");
-		return 0;   // Erreur par defaut
+		return 0;   // Default error
 	}
 
 
@@ -812,7 +812,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$pdf->SetFont('','', $default_font_size - 1);
 
 		// If France, show VAT mention if not applicable
-		if ($this->emetteur->country_code == 'FR' && $this->franchise == 1)
+		if ($this->issuer->country_code == 'FR' && $this->franchise == 1)
 		{
 			$pdf->SetFont('','B', $default_font_size - 2);
 			$pdf->SetXY($this->margin_left, $posy);
@@ -913,14 +913,14 @@ class pdf_couffignal_situation extends ModelePDFFactures
 					{
 						$pdf->SetXY($this->margin_left, $posy);
 						$pdf->SetFont('','B', $default_font_size - $diffsizetitle);
-						$pdf->MultiCell(100, 3, $outputlangs->transnoentities('PaymentByChequeOrderedTo',$this->emetteur->name),0,'L',0);
+						$pdf->MultiCell(100, 3, $outputlangs->transnoentities('PaymentByChequeOrderedTo',$this->issuer->name),0,'L',0);
 						$posy=$pdf->GetY()+1;
 
 			            if (!getDolGlobalInt('MAIN_PDF_HIDE_CHQ_ADDRESS'))
 			            {
 							$pdf->SetXY($this->margin_left, $posy);
 							$pdf->SetFont('','', $default_font_size - $diffsizetitle);
-							$pdf->MultiCell(100, 3, $outputlangs->convToOutputCharset($this->emetteur->getFullAddress()), 0, 'L', 0);
+							$pdf->MultiCell(100, 3, $outputlangs->convToOutputCharset($this->issuer->getFullAddress()), 0, 'L', 0);
 							$posy=$pdf->GetY()+2;
 			            }
 					}
@@ -1188,7 +1188,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		    $total_a_payer = $total_a_payer * 100 / $avancementGlobal;
 		}
 
-		// Todo : Fix incorect amount later on
+		// Todo : Fix incorrect amount later on
 		/*if(!empty($TPreviousInvoice)){
 		    $pdf->setY($tab2_top);
 		    $posy = $pdf->GetY();
@@ -1857,36 +1857,36 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		{
 			// We work to define prices using the price without tax
 			$result[6] = price2num($tot_sans_remise, 'MT');
-			$result[8] = price2num($tot_sans_remise * (1 + ( (($info_bits & 1)?0:$txtva) / 100)) + $localtaxes[0], 'MT');	// Selon TVA NPR ou non
-			$result8bis= price2num($tot_sans_remise * (1 + ( $txtva / 100)) + $localtaxes[0], 'MT');	// Si TVA consideree normale (non NPR)
+			$result[8] = price2num($tot_sans_remise * (1 + ( (($info_bits & 1)?0:$txtva) / 100)) + $localtaxes[0], 'MT');	// If VAT "NPR" or not
+			$result8bis= price2num($tot_sans_remise * (1 + ( $txtva / 100)) + $localtaxes[0], 'MT');	// If non "non NPR" VAT
 			$result[7] = price2num($result8bis - ($result[6] + $localtaxes[0]), 'MT');
 
 			$result[0] = price2num($tot_avec_remise, 'MT');
-			$result[2] = price2num($tot_avec_remise * (1 + ( (($info_bits & 1)?0:$txtva) / 100)) + $localtaxes[1], 'MT');	// Selon TVA NPR ou non
-			$result2bis= price2num($tot_avec_remise * (1 + ( $txtva / 100)) + $localtaxes[1], 'MT');	// Si TVA consideree normale (non NPR)
+			$result[2] = price2num($tot_avec_remise * (1 + ( (($info_bits & 1)?0:$txtva) / 100)) + $localtaxes[1], 'MT');	// If VAT "NPR" or not
+			$result2bis= price2num($tot_avec_remise * (1 + ( $txtva / 100)) + $localtaxes[1], 'MT');	// If non "non NPR" VAT
 			$result[1] = price2num($result2bis - ($result[0] + $localtaxes[1]), 'MT');	// Total VAT = TTC - (HT + localtax)
 
 			$result[3] = price2num($pu, 'MU');
-			$result[5] = price2num($pu * (1 + ( (($info_bits & 1)?0:$txtva) / 100)) + $localtaxes[2], 'MU');	// Selon TVA NPR ou non
-			$result5bis= price2num($pu * (1 + ($txtva / 100)) + $localtaxes[2], 'MU');	// Si TVA consideree normale (non NPR)
+			$result[5] = price2num($pu * (1 + ( (($info_bits & 1)?0:$txtva) / 100)) + $localtaxes[2], 'MU');	// If VAT "NPR" or not
+			$result5bis= price2num($pu * (1 + ($txtva / 100)) + $localtaxes[2], 'MU');	// If non "non NPR" VAT
 			$result[4] = price2num($result5bis - ($result[3] + $localtaxes[2]), 'MU');
 		}
 		else
 		{
 			// We work to define prices using the price with tax
 			$result[8] = price2num($tot_sans_remise + $localtaxes[0], 'MT');
-			$result[6] = price2num($tot_sans_remise / (1 + ((($info_bits & 1)?0:$txtva) / 100)), 'MT');	// Selon TVA NPR ou non
-			$result6bis= price2num($tot_sans_remise / (1 + ($txtva / 100)), 'MT');	// Si TVA consideree normale (non NPR)
+			$result[6] = price2num($tot_sans_remise / (1 + ((($info_bits & 1)?0:$txtva) / 100)), 'MT');	// If VAT "NPR" or not
+			$result6bis= price2num($tot_sans_remise / (1 + ($txtva / 100)), 'MT');	// If non "non NPR" VAT
 			$result[7] = price2num($result[8] - ($result6bis + $localtaxes[0]), 'MT');
 
 			$result[2] = price2num($tot_avec_remise + $localtaxes[1], 'MT');
-			$result[0] = price2num($tot_avec_remise / (1 + ((($info_bits & 1)?0:$txtva) / 100)), 'MT');	// Selon TVA NPR ou non
-			$result0bis= price2num($tot_avec_remise / (1 + ($txtva / 100)), 'MT');	// Si TVA consideree normale (non NPR)
+			$result[0] = price2num($tot_avec_remise / (1 + ((($info_bits & 1)?0:$txtva) / 100)), 'MT');	// If VAT "NPR" or not
+			$result0bis= price2num($tot_avec_remise / (1 + ($txtva / 100)), 'MT');	// If non "non NPR" VAT
 			$result[1] = price2num($result[2] - ($result0bis + $localtaxes[1]), 'MT');	// Total VAT = TTC - (HT + localtax)
 
 			$result[5] = price2num($pu + $localtaxes[2], 'MU');
-			$result[3] = price2num($pu / (1 + ((($info_bits & 1)?0:$txtva) / 100)), 'MU');	// Selon TVA NPR ou non
-			$result3bis= price2num($pu / (1 + ($txtva / 100)), 'MU');	// Si TVA consideree normale (non NPR)
+			$result[3] = price2num($pu / (1 + ((($info_bits & 1)?0:$txtva) / 100)), 'MU');	// If VAT "NPR" or not
+			$result3bis= price2num($pu / (1 + ($txtva / 100)), 'MU');	// If non "non NPR" VAT
 			$result[4] = price2num($result[5] - ($result3bis + $localtaxes[2]), 'MU');
 		}
 
@@ -2035,8 +2035,8 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		$pdf->SetXY($this->margin_left,$posy);
 
 		// Logo
-		$logo=$conf->mycompany->dir_output.'/logos/'.$this->emetteur->logo;
-		if ($this->emetteur->logo) {
+		$logo=$conf->mycompany->dir_output.'/logos/'.$this->issuer->logo;
+		if ($this->issuer->logo) {
 			if (is_readable($logo)) {
 			    $height = pdf_getHeightForLogo($logo);
 				$pdf->Image($logo, $this->margin_left, $posy, 0, $height);	// width=0 (auto)
@@ -2047,7 +2047,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 				$pdf->MultiCell($w, 3, $outputlangs->transnoentities("ErrorGoToGlobalSetup"), 0, 'L');
 			}
 		} else {
-			$text = $this->emetteur->name;
+			$text = $this->issuer->name;
 			$pdf->MultiCell($w, 4, $outputlangs->convToOutputCharset($text), 0, 'L');
 		}
 
@@ -2145,7 +2145,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 		if ($showaddress) {
 			$ref_height = max(42, $maxY + 5);
 			// Sender properties
-			$carac_emetteur = pdf_build_address($outputlangs, $this->emetteur, $object->thirdparty);
+			$carac_issuer = pdf_build_address($outputlangs, $this->issuer, $object->thirdparty);
 
 			// Show sender
 			$posy = getDolGlobalInt('MAIN_PDF_USE_ISO_LOCATION') ? 40 : $ref_height;
@@ -2169,13 +2169,13 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			$pdf->SetTextColor(0,0,60);
 			$pdf->SetXY($posx+2,$posy+3);
 			$pdf->SetFont('','B', $default_font_size);
-			$pdf->MultiCell($widthrecbox-2, 4, $outputlangs->convToOutputCharset($this->emetteur->name), 0, 'L');
+			$pdf->MultiCell($widthrecbox-2, 4, $outputlangs->convToOutputCharset($this->issuer->name), 0, 'L');
 			$posy=$pdf->getY();
 
 			// Show sender information
 			$pdf->SetXY($posx+2,$posy);
 			$pdf->SetFont('','', $default_font_size - 1);
-			$pdf->MultiCell($widthrecbox-2, 4, $carac_emetteur, 0, 'L');
+			$pdf->MultiCell($widthrecbox-2, 4, $carac_issuer, 0, 'L');
 
 
 			// If BILLING contact defined on invoice, we use it
@@ -2195,7 +2195,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			}
 
 			$carac_client_name= pdfBuildThirdpartyName($thirdparty, $outputlangs);
-			$carac_client=pdf_build_address($outputlangs,$this->emetteur,$object->thirdparty,($usecontact?$object->contact:''),$usecontact,'target',$object);
+			$carac_client=pdf_build_address($outputlangs,$this->issuer,$object->thirdparty,($usecontact?$object->contact:''),$usecontact,'target',$object);
 
 			// Show recipient
 			$widthrecbox=getDolGlobalInt('MAIN_PDF_USE_ISO_LOCATION') ? 92 : 100;
@@ -2232,7 +2232,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 
 
 	/**
-	 *   	Show footer of page. Need this->emetteur object
+	 *   	Show footer of page. Need this->issuer object
      *
 	 *   	@param	PDF			$pdf     			PDF
 	 * 		@param	Object		$object				Object to show
@@ -2244,7 +2244,7 @@ class pdf_couffignal_situation extends ModelePDFFactures
 	{
 		global $conf;
 		$showdetails = getDolGlobalInt('MAIN_GENERATE_DOCUMENTS_SHOW_FOOT_DETAILS');
-		return pdf_pagefoot($pdf, $outputlangs, 'INVOICE_FREE_TEXT', $this->emetteur, $this->margin_bottom, $this->margin_left, $this->page_height, $object, $showdetails, $hidefreetext);
+		return pdf_pagefoot($pdf, $outputlangs, 'INVOICE_FREE_TEXT', $this->issuer, $this->margin_bottom, $this->margin_left, $this->page_height, $object, $showdetails, $hidefreetext);
 	}
 
 


### PR DESCRIPTION
# NEW Autonaming
Autoname the new situation invoices as per their `situation_counter` (`S1`, `S2`, ...)

The `couffignal_situation` pdf is also changed to show the project name and ref in the "Marché" part on 1srt page as follow:
![image](https://github.com/user-attachments/assets/58675d76-b7a6-49e3-81d3-15e21a7f5711)