### PR TITLE
Resume orders project in pdf facture

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_couffignal_situation.modules.php
@@ -34,6 +34,7 @@ require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/pdf.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/couffignal/FactureTools.php';
 // TSubtotal
 if (isModEnabled('subtotal')) dol_include_once('/subtotal/class/subtotal.class.php');
 
@@ -1474,11 +1475,24 @@ class pdf_couffignal_situation extends ModelePDFFactures
 			$pdf->SetXY($this->margin_left + 2, $tab_top + $h);
 			$pdf->MultiCell($rect_width - 4, 2, $label, '', 'L');
 			$h += 4;
-		}		
+		}
+
+		/** Orders of projetcs */
+		$ordersTotalHt = FactureTools::getTotalHtOrdersLinkedToProjectOfInvoice($this->db, $object);
+		$linesOrders = [];
+		if (count($ordersTotalHt) > 0) {
+			$linesOrders = array_map(static function($v) {
+				return '<li>' . $v['ref_client'] . ' : ' . price($v['total_ht']) . ' HT </li>';
+			}, $ordersTotalHt);
+			array_unshift($linesOrders, '<ul>');
+			$linesOrders[] = '</ul>';
+		}
+
+		$pdf->writeHtml(implode($linesOrders));
+		$h += (4*count($ordersTotalHt));
+
 		$this->printRectBtp($pdf, $this->margin_left, $tab_top, $rect_width, $h + 3, $hidetop, $hidebottom);
 		$tab_top += ($h+5);
-
-
 
 		/****** Main Table on 1st page *****/
 		/** Table Data **/

--- a/htdocs/core/triggers/interface_99_modFacture_CouffignalFactureSituation.class.php
+++ b/htdocs/core/triggers/interface_99_modFacture_CouffignalFactureSituation.class.php
@@ -1,0 +1,100 @@
+<?php
+/* Copyright (C) ---Put here your own copyright and developer email---
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/triggers/interface_99_modFacture_CouffignalFactureSituation.class.php
+ * \ingroup facture
+ * \brief   Couffignal facture situation.
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/triggers/dolibarrtriggers.class.php';
+require_once DOL_DOCUMENT_ROOT.'/couffignal/FactureTools.php';
+
+
+/**
+ *  Class of triggers for MyModule module
+ */
+class InterfaceCouffignalFactureSituation extends DolibarrTriggers
+{
+	/**
+	 * Constructor
+	 *
+	 * @param DoliDB $db Database handler
+	 */
+	public function __construct($db)
+	{
+		$this->db = $db;
+
+		$this->name = preg_replace('/^Interface/i', '', get_class($this));
+		$this->family = "facture";
+		$this->description = "Couffignal facture situation.";
+		// 'development', 'experimental', 'dolibarr' or version
+		$this->version = 'development';
+		$this->picto = 'couffignal_facture_situation';
+	}
+
+	/**
+	 * Trigger name
+	 *
+	 * @return string Name of trigger file
+	 */
+	public function getName()
+	{
+		return $this->name;
+	}
+
+	/**
+	 * Trigger description
+	 *
+	 * @return string Description of trigger file
+	 */
+	public function getDesc()
+	{
+		return $this->description;
+	}
+
+
+	/**
+	 * Function called when a Dolibarrr business event is done.
+	 * All functions "runTrigger" are triggered if file
+	 * is inside directory core/triggers
+	 *
+	 * @param string 		$action 	Event action code
+	 * @param CommonObject 	$object 	Object
+	 * @param User 			$user 		Object user
+	 * @param Translate 	$langs 		Object langs
+	 * @param Conf 			$conf 		Object conf
+	 * @return int              		Return integer <0 if KO, 0 if no triggered ran, >0 if OK
+	 */
+	public function runTrigger($action, $object, User $user, Translate $langs, Conf $conf)
+	{
+		if (!isModEnabled('facture') || !isModEnabled('project')) {
+			return 0;
+		}
+
+		if ($action !== 'BILL_VALIDATE' || !($object instanceof Facture) || (int) $object->type !== Facture::TYPE_SITUATION) {
+			return 0;
+		}
+
+		if (FactureTools::lastSituationIsNotValid($this->db, $object)) {
+			setEventMessage($langs->trans('InvoiceSituationMustHaveOrdersImportedForBeingValidated'), 'warnings');
+			return -1;
+		}
+
+		return 1;
+	}
+}

--- a/htdocs/couffignal/CommandeTools.php
+++ b/htdocs/couffignal/CommandeTools.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tools for Commande class
+ */
+class CommandeTools
+{
+	/**
+	 * Get all validated orders from a project
+	 *
+	 * @param DoliDB $db Database handler
+	 * @param Project $project Project object
+	 * @return array
+	 */
+	public static function getOrdersValidatedFromProject(DoliDB $db, Project $project): array
+	{
+		$listOrdersRowId = $project->get_element_list('order', 'commande');
+
+		$orders = [];
+		foreach ($listOrdersRowId as $orderRowId) {
+			$order = new Commande($db);
+			$order->fetch($orderRowId);
+			if ($order->statut == Commande::STATUS_VALIDATED) {
+				$orders[] = $order;
+			}
+		}
+
+		return $orders;
+	}
+}

--- a/htdocs/couffignal/FactureTools.php
+++ b/htdocs/couffignal/FactureTools.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+require_once DOL_DOCUMENT_ROOT.'/couffignal/CommandeTools.php';
+
+/**
+ * Tools for Invoice class
+ */
+class FactureTools
+{
+	/**
+	 * Get total amount excluding tax of validated orders linked to the project of the invoice
+	 *
+	 * @param DoliDB $db Database handler
+	 * @param Facture $facture Invoice object
+	 * @return array Array of orders with ref_client and total_ht
+	 */
+	public static function getTotalHtOrdersLinkedToProjectOfInvoice(DoliDB $db, Facture $facture): array
+	{
+		if ($facture->project === null) {
+			$facture->fetch_project();
+		}
+
+		$orders = CommandeTools::getOrdersValidatedFromProject($db, $facture->project);
+
+		return array_map(static fn ($order) => ['ref_client' => $order->ref_client, 'total_ht' => $order->total_ht], $orders);
+	}
+
+	/**
+	 * valid if the amount of project orders corresponds to the amount of the last situation.
+	 *
+	 * @param DoliDB $db Database handler
+	 * @param Facture $facture Invoice object
+	 * @return bool Returns true if the last situation is not valid
+	 */
+	public static function lastSituationIsNotValid(DoliDB $db, Facture $facture): bool
+	{
+		$lastSituationCompletePrice = $facture->getLastSituationCompletePrice();
+		$totalHtOrders = self::getTotalHtOrdersLinkedToProjectOfInvoice($db, $facture);
+		$sumTotalHtOrders = round(array_sum(array_column($totalHtOrders, 'total_ht')), 2);
+
+		return !(abs($lastSituationCompletePrice - $sumTotalHtOrders) <= 0.01);
+	}
+}

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -233,6 +233,7 @@ AllowedInvoiceForRetainedWarranty=Retained warranty usable on the following type
 RetainedwarrantyDefaultPercent=Retained warranty default percent
 RetainedwarrantyOnlyForSituation=Make "retained warranty" available only for situation invoices
 RetainedwarrantyOnlyForSituationFinal=On situation invoices the global "retained warranty" deduction is applied only on the final situation
+InvoiceSituationMustHaveOrdersImportedForBeingValidated=Not all validated orders are in the latest available status invoice
 ToPayOn=To pay on %s
 toPayOn=to pay on %s
 RetainedWarranty=Retained Warranty

--- a/htdocs/langs/fr_FR/bills.lang
+++ b/htdocs/langs/fr_FR/bills.lang
@@ -233,6 +233,7 @@ AllowedInvoiceForRetainedWarranty=Garantie conservée utilisable sur les types d
 RetainedwarrantyDefaultPercent=Pourcentage par défaut de la retenue de garantie
 RetainedwarrantyOnlyForSituation=Rendre la "retenue de garantie" disponible uniquement pour les factures de situation
 RetainedwarrantyOnlyForSituationFinal=Sur les factures de situation, la déduction globale pour "retenue de garantie" n'est appliquée que sur la facture de situation finale
+InvoiceSituationMustHaveOrdersImportedForBeingValidated=Toutes les commandes validées ne sont pas dans la dernière facture de situation disponible
 ToPayOn=À payer le %s
 toPayOn=à payer le %s
 RetainedWarranty=Retenue de garantie


### PR DESCRIPTION
Permet d'afficher les OS du marche ainsi que les avenants dans une facture de projet.

Les os qui n'ont pas de ref client ne sont pas prisent en compte.
