### PR TITLE
FIX : v21 GETPOSTFLOAT for prorata in compta/facture/card.php

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -4249,7 +4249,7 @@ if ($action == 'create') {
 		// Use prorata discount
 		if (getDolGlobalString('INVOICE_USE_PRORATA_DISCOUNT')) {
 			// Get existing rate if any
-			$prorata_rate = GETPOST('prorata_rate', 'float');
+			$prorata_rate = GETPOSTFLOAT('prorata_rate');
 			if (empty($prorata_rate)) {
 				// On a situation, use previous situation value
 				if ($objectsrc instanceof Facture && !empty($objectsrc->prorata_rate)) {


### PR DESCRIPTION
Necessaire pour la v21 : GETPOST(xx, float') est devenu GETPOSTFLOAT

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

